### PR TITLE
Fix building the MSYS2 installer

### DIFF
--- a/msys2-installer/make-msys2-installer
+++ b/msys2-installer/make-msys2-installer
@@ -111,8 +111,8 @@ create_chroot_system() {
   mkdir -p var/log
   mkdir -p tmp
 
-  pacman -Syu --rootrebase "${_newmsys}"
-  pacman -S base --noconfirm --rootrebase "${_newmsys}"
+  pacman -Syu --root "${_newmsys}"
+  pacman -S base --noconfirm --root "${_newmsys}"
   _result=$?
   if [ "$_result" -ne "0" ]; then
     exit_cleanly "1" "failed to create newmsys2 via command 'pacman -S base --noconfirm --root ${_newmsys}'"


### PR DESCRIPTION
The available pacman executable does not know the `-rootrebase` option,
therefore we need to use the `-root` option.

This developer suggests that the `-rootrebase` option was introduced to
ask pacman to rebase the .dll files after installing everything into a
new root directory. However, we only ever plan to develop Git for
Windows on 64-bit setups, therefore rebasing is substantially less
crucial for us and we can totally live without it.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>