### PR TITLE
Introduce the git-for-windows repository to pacman

### DIFF
--- a/pacman/pacman.conf.i686
+++ b/pacman/pacman.conf.i686
@@ -69,6 +69,10 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
+[git-for-windows]
+Server = https://git-for-windows.github.io/pacman-repository/$arch
+SigLevel = Optional
+
 [mingw32]
 Include = /etc/pacman.d/mirrorlist.mingw32
 

--- a/pacman/pacman.conf.x86_64
+++ b/pacman/pacman.conf.x86_64
@@ -69,6 +69,10 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
+[git-for-windows]
+Server = https://git-for-windows.github.io/pacman-repository/$arch
+SigLevel = Optional
+
 [mingw32]
 Include = /etc/pacman.d/mirrorlist.mingw32
 


### PR DESCRIPTION
List it first so git-for-windows can override mingw / msys packages.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>