### PR TITLE
Switch the Git-for-Windows Pacman repository to the Bintray one

### DIFF
--- a/pacman/pacman.conf
+++ b/pacman/pacman.conf
@@ -70,7 +70,7 @@ LocalFileSigLevel = Optional
 # after the header, and they will be used before the default mirrors.
 
 [git-for-windows]
-Server = https://$repo.github.io/pacman-repository/$arch
+Server = https://dl.bintray.com/$repo/pacman/$arch
 SigLevel = Optional
 
 [mingw32]


### PR DESCRIPTION
Unfortunately, Pacman cannot handle the case where packages of the same
name but for different architectures are available.

So we still need to have two different repositories, one for i686 and
one for x86_64.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>