### PR TITLE
pacman: Do a sanity check for the final DB URL

### DIFF
--- a/pacman/0005-Do-a-sanity-check-before-maniplating-final-DB-URL.patch
+++ b/pacman/0005-Do-a-sanity-check-before-maniplating-final-DB-URL.patch
@@ -1,0 +1,52 @@
+From 8f30aeec9e5c9feab3df9a96ed618673083b0258 Mon Sep 17 00:00:00 2001
+From: David Macek <david.macek@gmail.com>
+Date: Mon, 13 Apr 2015 19:33:36 +0000
+Subject: [PATCH] libalpm: Do a sanity check before manipulating final DB URL
+
+The change in commit 9d96bed9d6b57 causes download errors for the .db.sig file
+in case the final URL for the .db file contains query strings or other
+unexpected stuff. This commit isn't intended to be a total solution, but it
+should eliminate the problem in the most obvious cases.
+---
+ lib/libalpm/be_sync.c | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/lib/libalpm/be_sync.c b/lib/libalpm/be_sync.c
+index 20130dc..56fd016 100644
+--- a/lib/libalpm/be_sync.c
++++ b/lib/libalpm/be_sync.c
+@@ -241,20 +241,26 @@ int SYMEXPORT alpm_db_update(int force, alpm_db_t *db)
+ 			unlink(sigpath);
+ 			free(sigpath);
+ 
+-			/* if we downloaded a DB, we want the .sig from the same server -
+-			   this information is only available from the internal downloader */
+-			if(handle->fetchcb == NULL) {
++			/* check if the final URL from internal downloader looks reasonable */
++			if(final_db_url != NULL) {
++				if(strlen(final_db_url) < 3 || strcmp(final_db_url + strlen(final_db_url) - 3, ".db") != 0) {
++					final_db_url = NULL;
++				}
++			}
++
++			/* if we downloaded a DB, we want the .sig from the same server */
++			if(final_db_url != NULL) {
+ 				/* print final_db_url into a buffer (leave space for .sig) */
+ 				len = strlen(final_db_url) + 5;
+ 			} else {
+-				/* print server + filename into a buffer (leave space for .sig) */
++				/* print server + filename into a buffer (leave space for .db.sig) */
+ 				len = strlen(server) + strlen(db->treename) + 9;
+ 			}
+ 
+ 			/* TODO fix leak syncpath and umask unset */
+ 			MALLOC(payload.fileurl, len, RET_ERR(handle, ALPM_ERR_MEMORY, -1));
+ 
+-			if(handle->fetchcb == NULL) {
++			if(final_db_url != NULL) {
+ 				snprintf(payload.fileurl, len, "%s.sig", final_db_url);
+ 			} else {
+ 				snprintf(payload.fileurl, len, "%s/%s.db.sig", server, db->treename);
+-- 
+2.3.5
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -49,7 +49,7 @@ backup=("etc/pacman.conf"
         "etc/makepkg.conf"
         "etc/makepkg_mingw32.conf"
         "etc/makepkg_mingw64.conf")
-source=("$pkgname"::'git://github.com/Alexpux/MSYS2-pacman.git'
+source=("$pkgname"::'git+https://github.com/Alexpux/MSYS2-pacman.git'
         "pacman.conf"
         "makepkg.conf"
         "makepkg_mingw32.conf"

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 _base_ver=4.2.0
-pkgver=4.2.0.6100.077bd02
+pkgver=4.2.0.6125.274527d
 pkgrel=1
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
@@ -58,7 +58,8 @@ source=("$pkgname"::'git://github.com/Alexpux/MSYS2-pacman.git'
         "0001-more-debugging-info.patch"
         "0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch"
         "0003-use-busybox-for-msys2-post-installs.patch"
-        "0004-Link-pacman-with-static-libraries.patch")
+        "0004-Link-pacman-with-static-libraries.patch"
+        "0005-Do-a-sanity-check-before-maniplating-final-DB-URL.patch")
 md5sums=('SKIP'
          'a74be5548ab4743ef05712ebff0b8472'
          'fc9e737a24f08f842f1f4c54bdcaa653'
@@ -68,7 +69,8 @@ md5sums=('SKIP'
          '3478ac5ab27b8cdb289d1ac3792b16ec'
          'feb2bcc62db05f7bc6ac97d43dd0643a'
          '9ee3ca289031ca9c92db2805b75c1944'
-         '99f8ee6e6df141c9fa98f186ba8fa79c')
+         '99f8ee6e6df141c9fa98f186ba8fa79c'
+         '37f1dddc5a448fecc983ccad77855c7d')
 
 pkgver() {
   cd "$srcdir/$pkgname"
@@ -82,6 +84,7 @@ prepare() {
   #git am "$srcdir"/0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch
   #git am "$srcdir"/0003-use-busybox-for-msys2-post-installs.patch
   git am "$srcdir"/0004-Link-pacman-with-static-libraries.patch
+  git am "$srcdir"/0005-Do-a-sanity-check-before-maniplating-final-DB-URL.patch
   
   # Workaround for symlinks
   rm src/util/util-common.{h,c}


### PR DESCRIPTION
When using the *internal* downloader the returned `final_db_url` is
appended by the postfix `.sig` without checking if the `final_db_url` is
indeed sane. Possible redirects by the server *could* have altered it and
therefore it should be checked before being processed any further.

The pacman ML already contained a patch for this kind of behavior. This
commit will apply that patch before building pacman for *MSYS2*.

Signed-off-by: nalla <nalla@hamal.uberspace.de>