### PR TITLE
git-flow package now uses AVH edition

### DIFF
--- a/git-flow/PKGBUILD
+++ b/git-flow/PKGBUILD
@@ -2,34 +2,18 @@
 
 _realname=git-flow
 pkgname=("${_realname}")
-pkgver=0.4.1.108.g15aab26
+pkgver=1.8.0.r58.gd441201
 pkgrel=1
-pkgdesc="Git extensions to provide high-level repository operations for Vincent Driessen's branching model"
+pkgdesc="AVH Edition of the git extensions to provide high-level repository operations for Vincent Driessen's branching model"
 arch=('i686' 'x86_64')
 license=('BSD')
 depends=('git' 'util-linux')
 url="http://nvie.com/posts/a-successful-git-branching-model/"
-source=("${_realname}"::"git+https://github.com/nvie/gitflow.git#branch=develop")
+source=("${_realname}"::"git+https://github.com/petervanderdoes/gitflow-avh.git#branch=develop")
 sha1sums=('SKIP')
-
-pkgver() {
-  cd "${srcdir}/${_realname}"
-
-  # Need to create sane tags to allow `git describe` to work
-  for t in $(git tag -l | grep '^[0-9]')
-  do
-    git rev-parse --quiet --verify v$t >/dev/null ||
-    git tag v$t $t^2
-  done
-
-  git describe --tags |
-  sed -e 's/^v//' -e 'y/-/./'
-}
 
 prepare () {
   cd "${srcdir}/${_realname}"
-
-  git submodule update --init
 
   # Make sure that gitflow-shFlags is handled properly
   test true = "$(git config core.symlinks)" || {


### PR DESCRIPTION
The original nvie/git-flow repository is abandoned and no longer maintained. This package now refers to Git Flow AVH Edition which is maintained by Peter van der Does:

https://github.com/petervanderdoes/gitflow-avh

Details:

* Removed `pkgver()` function as its processing of tags is confusing and seems to not be needed, at least for the AVH edition.
* `pkgver` version's 4th component begins with `r` now (it didn't before) as recommended by [the archlinux documentation][1].

This resolves issue [#416][2].

[1]: https://wiki.archlinux.org/index.php/VCS_package_guidelines#The_pkgver.28.29_function
[2]: https://github.com/git-for-windows/git/issues/416