### PR TITLE
readline: convert clipboard data to UTF-8 encoding

### DIFF
--- a/readline/PKGBUILD
+++ b/readline/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=('libreadline' 'libreadline-devel')
 _basever=6.3
 _patchlevel=008 #prepare for some patches
 pkgver=$_basever.$_patchlevel
-pkgrel=5
+pkgrel=6
 pkgdesc="GNU readline library"
 arch=('i686' 'x86_64')
 url="http://tiswww.case.edu/php/chet/readline/rltop.html"
@@ -15,7 +15,8 @@ makedepends=('ncurses-devel')
 options=('!emptydirs')
 source=(http://ftp.gnu.org/gnu/readline/readline-$_basever.tar.gz{,.sig}
         readline-6.3-cygwin.patch
-        readline-6.3-msys2.patch)
+        readline-6.3-msys2.patch
+        readline-6.3-paste-utf8.patch)
 if [ $_patchlevel -gt 00 ]; then
     for (( p=1; p<=$((10#${_patchlevel})); p++ )); do
         source=(${source[@]} http://ftp.gnu.org/gnu/readline/readline-$_basever-patches/readline${_basever//./}-$(printf "%03d" $p){,.sig})
@@ -25,6 +26,7 @@ md5sums=('33c8fb279e981274f485fd91da77e94a'
          'SKIP'
          'f31ee9a5c41cee11c0dda1c13203dac9'
          '303e24bd011e0f812a268b4d84e19bd6'
+         '7599e0381560c394b707d6fead8b3afb'
          '4343f5ea9b0f42447f102fb61576b398'
          'SKIP'
          '700295212f7e2978577feaee584afddb'
@@ -50,6 +52,7 @@ prepare() {
   done
   patch -p1 -i $srcdir/readline-6.3-cygwin.patch
   patch -p1 -i $srcdir/readline-6.3-msys2.patch
+  patch -p1 -i $srcdir/readline-6.3-paste-utf8.patch
 }
 
 build() {

--- a/readline/readline-6.3-paste-utf8.patch
+++ b/readline/readline-6.3-paste-utf8.patch
@@ -1,0 +1,54 @@
+diff -Naur readline-6.3-orig/kill.c readline-6.3/kill.c
+--- readline-6.3-orig/kill.c	2010-12-07 01:44:58.000000000 +0100
++++ readline-6.3/kill.c	2015-12-17 20:08:50.652036500 +0100
+@@ -660,17 +660,41 @@
+ #if defined (__CYGWIN__)
+ #include <windows.h>
+ 
++static char*
++utf16_to_utf8 (wdata)
++     wchar_t *wdata;
++{
++  int size;
++  char *data;
++
++  size = WideCharToMultiByte (CP_UTF8, 0, wdata, -1, NULL, 0, NULL, NULL);
++  if (size == 0)
++    return NULL;
++
++  data = xmalloc (size);
++  if (WideCharToMultiByte (CP_UTF8, 0, wdata, -1, data, size, NULL, NULL) != size)
++  {
++    xfree (data);
++    return NULL;
++  }
++
++  return data;
++}
++
+ int
+ rl_paste_from_clipboard (count, key)
+      int count, key;
+ {
++  wchar_t *wdata;
+   char *data, *ptr;
+   int len;
+ 
+   if (OpenClipboard (NULL) == 0)
+     return (0);
+ 
+-  data = (char *)GetClipboardData (CF_TEXT);
++  wdata = (wchar_t *)GetClipboardData(CF_UNICODETEXT);
++  CloseClipboard ();
++  data = utf16_to_utf8 (wdata);
+   if (data)
+     {
+       ptr = strchr (data, '\r');
+@@ -687,7 +711,6 @@
+       rl_insert_text (ptr);
+       if (ptr != data)
+ 	xfree (ptr);
+-      CloseClipboard ();
+     }
+   return (0);
+ }


### PR DESCRIPTION
The call to GetClipboardData(CF_TEXT) returns the text in the system
encoding, which was then incorrectly treated as UTF-8 encoded. Instead we
need to use GetClipboardData(CF_UNICODETEXT) to get the text in UTF-16,
followed by a conversion to UTF-8.

Also fixed a problem were CloseClipboard was only called if
GetClipboardData returns non-null. According to the documentation, every
successful call to OpenClipboard should be matched with a call to
CloseClipboard.