### PR TITLE
[RFC] Add/inc epoch in packages changed from upstream

### DIFF
--- a/bash/PKGBUILD
+++ b/bash/PKGBUILD
@@ -7,6 +7,7 @@ _basever=4.4
 _patchlevel=019 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
 pkgrel=2
+epoch=1
 pkgdesc="The GNU Bourne Again shell"
 arch=('i686' 'x86_64')
 license=('GPL')

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -4,6 +4,7 @@ pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=7.59.0
 pkgrel=1
+epoch=1
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.haxx.se"

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -6,6 +6,7 @@
 pkgname=filesystem
 pkgver=2018.02
 pkgrel=2
+epoch=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')

--- a/gawk/PKGBUILD
+++ b/gawk/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=gawk
 pkgver=4.2.1
 pkgrel=1
+epoch=1
 pkgdesc="GNU version of awk"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/gawk/"

--- a/git-flow/PKGBUILD
+++ b/git-flow/PKGBUILD
@@ -4,6 +4,7 @@ _realname=git-flow
 pkgname="${_realname}"
 pkgver=1.11.0
 pkgrel=1
+epoch=1
 pkgdesc="Git extensions to provide high-level repository operations for Vincent Driessen's branching model (AVH edition)"
 arch=('i686' 'x86_64')
 license=('BSD')

--- a/heimdal/PKGBUILD
+++ b/heimdal/PKGBUILD
@@ -4,6 +4,7 @@ pkgbase=heimdal
 pkgname=('heimdal' 'heimdal-libs' 'heimdal-devel')
 pkgver=7.5.0
 pkgrel=1
+epoch=1
 pkgdesc="Implementation of Kerberos V5 libraries"
 arch=('i686' 'x86_64')
 url="https://www.h5l.org/"

--- a/inc-epoch.sh
+++ b/inc-epoch.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Adds or increments epoch variable in PKGBUILDs for packages that are changed
+# from upstream.
+
+set -o nounset
+set -o errtrace
+set -o errexit
+set -o pipefail
+
+die() {
+    echo "$1"
+    exit 1
+}
+
+usage() {
+    echo "$0 [--upstream <refspec>] [--] [file] ..."
+    exit 0
+}
+
+if ! cdup="$(git rev-parse --show-cdup)"; then
+    die "No repository here!"
+fi
+
+upstream="upstream/master"
+
+while [[ -n "${1:-}" ]]; do
+    case "$1" in
+        -u|--upstream)
+            shift
+            upstream="$1" || die "Missing argument"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+git rev-parse --verify --quiet "$upstream" &>/dev/null || die "Invalid refspec $upstream"
+
+declare -a add=() inc=()
+while IFS='' read -r p; do
+    if [[ "$(< "$p")" =~ $'\n'epoch=([0-9]*)$'\n' ]]; then
+        diff="$(git diff -U0 "$upstream" -- "$p")"
+        if [[ ! "$diff" =~ $'\n'\+epoch= ]]; then
+            inc+=("$p")
+        fi
+    else
+        add+=("$p")
+    fi
+done < <(\
+    git diff --name-only "$upstream" -- "${@:-.}" \
+    | cut -d '/' -f 1 | sort | uniq | sed 's/$/\/PKGBUILD/' \
+    | while IFS='' read -r f; do f="${cdup}${f}"; [[ -f "$f" ]] && echo "$f"; done
+)
+(( ${#inc[@]} )) && sed -ri 's/^epoch=([0-9]+)/echo "epoch=$((\1+1))"/e' "${inc[@]}"
+(( ${#add[@]} )) && sed -i '/^pkgrel=/a\'$'\n''epoch=1'$'\n' "${add[@]}"
+
+exit 0
+
+# vim: set ts=4 sw=4 et ai:

--- a/irssi/PKGBUILD
+++ b/irssi/PKGBUILD
@@ -7,6 +7,7 @@ replaces=(irssi-git)
 conflicts=(irssi-git)
 pkgver=1.0.2
 pkgrel=1
+epoch=1
 pkgdesc="Modular text mode IRC client with Perl scripting"
 arch=('i686' 'x86_64')
 url="https://irssi.org/"

--- a/libcrypt/PKGBUILD
+++ b/libcrypt/PKGBUILD
@@ -4,6 +4,7 @@ pkgbase=libcrypt
 pkgname=('libcrypt' 'libcrypt-devel')
 pkgver=2.1
 pkgrel=1
+epoch=1
 pkgdesc="Encryption/Decryption utility and library"
 groups=('base')
 arch=('i686' 'x86_64')

--- a/libpsl/PKGBUILD
+++ b/libpsl/PKGBUILD
@@ -4,6 +4,7 @@ pkgbase='libpsl'
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=0.19.1
 pkgrel=1
+epoch=1
 pkgdesc='Public Suffix List library'
 url='https://github.com/rockdaboot/libpsl'
 arch=('i686' 'x86_64')

--- a/man-db/PKGBUILD
+++ b/man-db/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=man-db
 pkgver=2.7.6
 pkgrel=2
+epoch=1
 pkgdesc="A utility for reading man pages"
 arch=('i686' 'x86_64')
 url="http://www.nongnu.org/man-db/"

--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=mintty
 pkgver=2.8.4
 pkgrel=1
-epoch=1
+epoch=2
 pkgdesc="Terminal emulator with native Windows look and feel"
 arch=('i686' 'x86_64')
 license=('GPL3')

--- a/mksh/PKGBUILD
+++ b/mksh/PKGBUILD
@@ -5,6 +5,7 @@ _ver=56c
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=1
+epoch=1
 pkgdesc="The MirBSD Korn Shell"
 arch=("i686" "x86_64")
 url="https://www.mirbsd.org/mksh.htm"

--- a/mpfr/PKGBUILD
+++ b/mpfr/PKGBUILD
@@ -9,6 +9,7 @@ if [ -n "${_patchlevel}" ]; then
 fi
 #pkgver=${_pkgver}
 pkgrel=1
+epoch=1
 pkgdesc="Multiple-precision floating-point library"
 arch=('i686' 'x86_64')
 url="http://www.mpfr.org/"

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -5,6 +5,7 @@ pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=2.10.0
 pkgrel=2
+epoch=1
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"

--- a/mutt/PKGBUILD
+++ b/mutt/PKGBUILD
@@ -4,6 +4,7 @@
 pkgname=mutt
 pkgver=1.9.3
 pkgrel=1
+epoch=1
 pkgdesc='Small but very powerful text-based mail client (net-utils)'
 url='http://www.mutt.org/'
 license=('GPL')

--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -5,6 +5,7 @@ _ver=1.0.2n
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=5
+epoch=1
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'

--- a/p7zip/PKGBUILD
+++ b/p7zip/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=p7zip
 pkgver=16.02
 pkgrel=1
+epoch=1
 pkgdesc='Command-line version of the 7zip compressed file archiver'
 url='https://p7zip.sourceforge.io/'
 license=('GPL' 'custom')

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,6 +5,7 @@
 pkgname=pacman
 pkgver=5.0.1
 pkgrel=5
+epoch=1
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"

--- a/perl-HTML-Parser/PKGBUILD
+++ b/perl-HTML-Parser/PKGBUILD
@@ -4,6 +4,7 @@ _realname=HTML-Parser
 pkgname=perl-${_realname}
 pkgver=3.72
 pkgrel=2
+epoch=1
 pkgdesc="Perl HTML parser class"
 arch=('i686' 'x86_64')
 license=('PerlArtistic')

--- a/perl-Locale-Gettext/PKGBUILD
+++ b/perl-Locale-Gettext/PKGBUILD
@@ -4,6 +4,7 @@ _realname=Locale-Gettext
 pkgname=perl-${_realname}
 pkgver=1.07
 pkgrel=2
+epoch=1
 groups=('perl-modules')
 pkgdesc="Permits access from Perl to the gettext() family of functions"
 arch=('i686' 'x86_64')

--- a/perl-Net-SSLeay/PKGBUILD
+++ b/perl-Net-SSLeay/PKGBUILD
@@ -4,6 +4,7 @@ _realname=Net-SSLeay
 pkgname=perl-${_realname}
 pkgver=1.84
 pkgrel=1
+epoch=1
 pkgdesc="Perl extension for using OpenSSL"
 arch=('i686' 'x86_64')
 license=('custom:BSD')

--- a/perl-TermReadKey/PKGBUILD
+++ b/perl-TermReadKey/PKGBUILD
@@ -4,6 +4,7 @@ _realname=TermReadKey
 pkgname=perl-${_realname}
 pkgver=2.37
 pkgrel=2
+epoch=1
 pkgdesc="Provides simple control over terminal driver modes"
 arch=('i686' 'x86_64')
 license=('custom')

--- a/perl-XML-Parser/PKGBUILD
+++ b/perl-XML-Parser/PKGBUILD
@@ -4,6 +4,7 @@ _realname=XML-Parser
 pkgname=perl-${_realname}
 pkgver=2.44
 pkgrel=4
+epoch=1
 pkgdesc="Expat-based XML parser module for perl"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')

--- a/perl-YAML-Syck/PKGBUILD
+++ b/perl-YAML-Syck/PKGBUILD
@@ -4,6 +4,7 @@ _realname=YAML-Syck
 pkgname=perl-YAML-Syck
 pkgver=1.30
 pkgrel=1
+epoch=1
 pkgdesc="Fast, lightweight YAML loader and dumper"
 arch=('i686' 'x86_64')
 url="http://search.cpan.org/dist/YAML-Syck/"

--- a/perl-getopt-argvfile/PKGBUILD
+++ b/perl-getopt-argvfile/PKGBUILD
@@ -6,6 +6,7 @@
 pkgname=perl-getopt-argvfile
 pkgver=1.11
 pkgrel=8
+epoch=1
 pkgdesc="Take options from files"
 arch=('any')
 url="http://search.cpan.org/~JSTENZEL/Getopt-ArgvFile"

--- a/perl/PKGBUILD
+++ b/perl/PKGBUILD
@@ -4,6 +4,7 @@ pkgname=perl
 pkgver=5.26.1
 _gccver=6.3.0
 pkgrel=3
+epoch=1
 pkgdesc="A highly capable, feature-rich programming language"
 arch=(i686 x86_64)
 license=('GPL')

--- a/publicsuffix-list/PKGBUILD
+++ b/publicsuffix-list/PKGBUILD
@@ -4,6 +4,7 @@ pkgname=publicsuffix-list
 _gitcommit=ffb052a26672745790ec8a3f78c50c03e4dc935d
 pkgver=20170929.553.ffb052a
 pkgrel=1
+epoch=1
 pkgdesc='Cross-vendor public domain suffix database'
 url='https://github.com/publicsuffix/list'
 arch=('any')

--- a/readline/PKGBUILD
+++ b/readline/PKGBUILD
@@ -6,6 +6,7 @@ _basever=7.0
 _patchlevel=003 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
 pkgrel=1
+epoch=1
 pkgdesc="GNU readline library"
 arch=('i686' 'x86_64')
 url="https://tiswww.case.edu/php/chet/readline/rltop.html"

--- a/subversion/PKGBUILD
+++ b/subversion/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=subversion
 pkgver=1.9.7
 pkgrel=3
+epoch=1
 pkgdesc="A Modern Concurrent Version Control System"
 arch=('i686' 'x86_64')
 url="https://subversion.apache.org/"

--- a/tig/PKGBUILD
+++ b/tig/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=tig
 pkgver=2.3.3
 pkgrel=1
+epoch=1
 pkgdesc='Text-mode interface for Git'
 depends=('git' 'libreadline' 'ncurses')
 makedepends=('asciidoc' 'xmlto' 'libreadline-devel' 'ncurses-devel' 'libiconv-devel')

--- a/tmux/PKGBUILD
+++ b/tmux/PKGBUILD
@@ -3,6 +3,7 @@
 pkgname=tmux
 pkgver=2.6
 pkgrel=1
+epoch=1
 pkgdesc='A terminal multiplexer'
 url='https://tmux.github.io/'
 arch=('i686' 'x86_64')

--- a/txt2html/PKGBUILD
+++ b/txt2html/PKGBUILD
@@ -4,6 +4,7 @@
 pkgname=txt2html
 pkgver=2.5201
 pkgrel=1
+epoch=1
 pkgdesc="Convert plain text files to HTML"
 arch=('i686' 'x86_64')
 url="http://txt2html.sourceforge.net/"

--- a/tzcode/PKGBUILD
+++ b/tzcode/PKGBUILD
@@ -5,6 +5,7 @@ _ver=2018c
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=1
+epoch=1
 pkgdesc="Sources for time zone and daylight saving time data"
 arch=('i686' 'x86_64')
 url="https://www.iana.org/time-zones"

--- a/vifm/PKGBUILD
+++ b/vifm/PKGBUILD
@@ -5,6 +5,7 @@
 pkgname=vifm
 pkgver=0.9
 pkgrel=1
+epoch=1
 pkgdesc="Ncurses based file manager with vi like keybindings"
 arch=('i686' 'x86_64')
 url="http://vifm.info/"


### PR DESCRIPTION
This is a proposed fix for issue git-for-windows/git#1571; it tells pacman that the packages in this repository that differ from msys2 proper supersede the ones in msys's repositories by setting or increasing epoch.

A maintenance script to add and update epoch is included in the commit. It does require a remote pointing to the upstream git repo.

Usage (in repo root dir):
```sh
$ ./inc-epoch.sh [--upstream <refspec>] [--] [file] ...
```
There's probably a better location to put this script, please comment.