### PR TITLE
Fix msys2-runtime/update-patches.sh format-patch

### DIFF
--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -19,8 +19,11 @@ die "Clean worktree required"
 git rm 0*.patch ||
 die "Could not remove previous patches"
 
+merging_rebase_start="$(git -C src/msys2-runtime \
+    rev-parse --verify --quiet HEAD^{/Start.the.merging.rebase})"
+
 git -c core.abbrev=7 -C src/msys2-runtime format-patch -o ../.. --signature=2.9.0 \
-	$base_tag.. ^HEAD^{/Start.the.merging.rebase} ||
+	$base_tag.. ${merging_rebase_start:+^$merging_rebase_start} ||
 die "Could not generate new patch set"
 
 patches="$(ls 0*.patch)" &&


### PR DESCRIPTION
Handle the case that `^HEAD^{/Start.the.merging.rebase}` doesn't match
anything by checking before calling format-patch.

Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>

Note: Not sure why it doesn't find a match, since it seems expected, but I barely know what's going on :)