### PR TITLE
Split .pdb generation into separate files

### DIFF
--- a/msys2-runtime/0058-Split-.pdb-generation-into-separate-files.patch
+++ b/msys2-runtime/0058-Split-.pdb-generation-into-separate-files.patch
@@ -1,0 +1,80 @@
+From 93291a3f7cbcd9e4d08ec76049dae2bcf29ae92c Mon Sep 17 00:00:00 2001
+From: Dakota Hawkins <dakotahawkins@gmail.com>
+Date: Fri, 13 Jul 2018 00:08:55 -0400
+Subject: [PATCH 58/N] Split .pdb generation into separate files
+
+Modified .dll and .pdb are placed in windebug subfolder.
+
+Fixes git-for-windows/git#356
+
+Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>
+---
+ winsup/cygwin/Makefile.in | 19 +++++++++++++------
+ 1 file changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/winsup/cygwin/Makefile.in b/winsup/cygwin/Makefile.in
+index 315ef7c..6be8ef4 100644
+--- a/winsup/cygwin/Makefile.in
++++ b/winsup/cygwin/Makefile.in
+@@ -587,12 +587,14 @@ install: install-libs install-headers install-man install-ldif install_target \
+ uninstall: uninstall-libs uninstall-headers uninstall-man
+ 
+ install-libs: $(TARGET_LIBS)
+-	@$(MKDIRP) $(DESTDIR)$(bindir)
++	@$(MKDIRP) $(DESTDIR)$(bindir)/windebug
+ 	$(INSTALL_PROGRAM) $(TEST_DLL_NAME) $(DESTDIR)$(bindir)/$(DLL_NAME); \
+ 	for i in $^; do \
+ 	    $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/lib/`basename $$i` ; \
+-	done
+-	$(INSTALL_DATA) msys-2.0.pdb $(DESTDIR)$(bindir)/msys-2.0.pdb
++	done; \
++	for i in windebug/*.* ; do \
++	    $(INSTALL_DATA) $$i $(DESTDIR)$(bindir)/windebug/`basename $$i` ; \
++	done; \
+ 	cd $(DESTDIR)$(tooldir)/lib && ln -sf libmsys-2.0.a libg.a
+ 
+ install-headers:
+@@ -630,6 +632,7 @@ install_host:
+ 
+ uninstall-libs: $(TARGET_LIBS)
+ 	rm -f $(bindir)/$(DLL_NAME); \
++	rm -fr $(bindir)/windebug; \
+ 	for i in $^; do \
+ 	    rm -f $(tooldir)/lib/$$i ; \
+ 	done
+@@ -658,7 +661,8 @@ uninstall-man:
+ 	done
+ 
+ clean distclean realclean:
+-	-rm -f *.o *.dll *.pdb *.a *.exp junk *.base version.cc *.exe *.d *stamp* *_magic.h sigfe.s msys.def globals.h
++	-rm -f *.o *.dll *.a *.exp junk *.base version.cc *.exe *.d *stamp* *_magic.h sigfe.s msys.def globals.h
++	-rm -fr windebug
+ 	-@$(MAKE) -C ${cygserver_blddir} libclean
+ 
+ maintainer-clean: clean
+@@ -672,7 +676,7 @@ $(LDSCRIPT): $(LDSCRIPT).in
+ 	$(CC) -E - -P < $^ -o $@
+ 
+ # Rule to build msys-2.0.dll
+-$(TEST_DLL_NAME): $(LDSCRIPT) $(DLL_OFILES) $(LIBSERVER) $(LIBC) $(LIBM) $(API_VER) Makefile $(VERSION_OFILES)
++$(TEST_DLL_NAME): $(LDSCRIPT) dllfixdbg $(DLL_OFILES) $(LIBSERVER) $(LIBC) $(LIBM) $(API_VER) Makefile $(VERSION_OFILES)
+ 	$(CXX) $(CXXFLAGS) \
+ 	-mno-use-libstdc-wrappers -L${WINDOWS_LIBDIR} \
+ 	-Wl,--gc-sections $(nostdlib) -Wl,-T$(firstword $^) -static \
+@@ -680,9 +684,12 @@ $(TEST_DLL_NAME): $(LDSCRIPT) $(DLL_OFILES) $(LIBSERVER) $(LIBC) $(LIBM) $(API_V
+ 	-e $(DLL_ENTRY) $(DEF_FILE) $(DLL_OFILES) $(VERSION_OFILES) \
+ 	$(MALLOC_OBJ) $(LIBSERVER) $(LIBM) $(LIBC) \
+ 	-lgcc $(DLL_IMPORTS) -Wl,-Map,msys.map
++	@mkdir windebug
+ 	MINGW_PREFIX=/mingw32 && \
+ 	case "$$(uname -m)" in x86_64) MINGW_PREFIX=/mingw64;; esac && \
+-	$$MINGW_PREFIX/bin/cv2pdb "$@" "$@" ${patsubst %0.dll,%-2.0.pdb,$@}
++	$$MINGW_PREFIX/bin/cv2pdb "$@" "windebug/${patsubst %0.dll,%-2.0.dll,$@}" windebug/${patsubst %0.dll,%-2.0.pdb,$@}
++	@$(word 2,$^) $(OBJDUMP) $(OBJCOPY) $@ ${patsubst %0.dll,%-2.0.dbg,$@}
++	@rm -f ${patsubst %0.dll,%-2.0.dbg,$@}
+ 	@ln -f $@ new-$(DLL_NAME)
+ 
+ # Rule to build libmsys-2.0.a
+-- 
+2.9.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -81,7 +81,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0054-fixup-kill-kill-Win32-processes-more-gently.patch
         0055-srandomdev-avoid-warning-about-uninitialized-use.patch
         0056-squash-Fix-incorrect-path-conversion-trailing-slash.patch
-        0057-Cygwin-Fixing-the-math-behind-rounding-down-ch.stack.patch)
+        0057-Cygwin-Fixing-the-math-behind-rounding-down-ch.stack.patch
+        0058-Split-.pdb-generation-into-separate-files.patch)
 sha256sums=('SKIP'
             '2a77753affdcf800acf208cb50f5c8008a7ea868209a6871247a7b2228685e0d'
             '0ce1b1cc6ce1a98fa07be518b0c7b2a005a5e22910f3c3fe7f7ff7bb59bafb98'
@@ -139,7 +140,8 @@ sha256sums=('SKIP'
             '87d1f0e9d3b4ebdbcffe64d27e7c1f32220cf5d74a681ac1a8dadbc057224378'
             '3ec38f7710402051360a2487c1d3783aff9dae2541e2feafb0074a7e9a618888'
             'b977786a27ecfe12d1211f4c21368ef57738b027b20910c830bfad3ff2879aba'
-            '40d8b815a9325e0d3253c9ac5d402556235a9e43b874fa1c587798b743f3d9c2')
+            '40d8b815a9325e0d3253c9ac5d402556235a9e43b874fa1c587798b743f3d9c2'
+            'c88d57c394640cd85d07a0bb8c602b7c53d0436372b689fe9042562275752252')
 
 # Helper macro to help make tasks easier #
 del_file_exists() {
@@ -212,6 +214,7 @@ prepare() {
   git am --committer-date-is-author-date "${srcdir}"/0055-srandomdev-avoid-warning-about-uninitialized-use.patch
   git am --committer-date-is-author-date "${srcdir}"/0056-squash-Fix-incorrect-path-conversion-trailing-slash.patch
   git am --committer-date-is-author-date "${srcdir}"/0057-Cygwin-Fixing-the-math-behind-rounding-down-ch.stack.patch
+  git am --committer-date-is-author-date "${srcdir}"/0058-Split-.pdb-generation-into-separate-files.patch
 }
 
 build() {
@@ -257,7 +260,7 @@ package_msys2-runtime() {
 
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
-  rm -f "${pkgdir}"/usr/bin/msys-2.0.pdb
+  rm -fr "${pkgdir}"/usr/bin/windebug
   rm -f "${pkgdir}"/usr/bin/cyglsa-config
   rm -f "${pkgdir}"/usr/bin/cyglsa.dll
   rm -f "${pkgdir}"/usr/bin/cyglsa64.dll
@@ -275,7 +278,7 @@ package_msys2-runtime-devel() {
   replaces=('libcatgets-devel')
 
   mkdir -p "${pkgdir}"/usr/bin
-  cp -f "${srcdir}"/dest/usr/bin/msys-2.0.pdb "${pkgdir}"/usr/bin/
+  cp -R "${srcdir}"/dest/usr/bin/windebug/. "${pkgdir}"/usr/bin/
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/include "${pkgdir}"/usr/
   rm -f "${pkgdir}"/usr/include/iconv.h
   rm -f "${pkgdir}"/usr/include/unctrl.h

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -231,8 +231,10 @@ build() {
     OPTIM="-O2"
   fi
 
-  CFLAGS="$OPTIM -pipe -ggdb"
-  CXXFLAGS="$OPTIM -pipe -ggdb"
+  # Debug settings for cv2pdb based on discussion in this issue:
+  # https://github.com/rainers/cv2pdb/issues/30
+  CFLAGS="$OPTIM -pipe -gdwarf-2 -gstrict-dwarf -fno-omit-frame-pointer"
+  CXXFLAGS="$OPTIM -pipe -gdwarf-2 -gstrict-dwarf -fno-omit-frame-pointer"
 
   "${srcdir}"/msys2-runtime/configure \
     --prefix=/usr \


### PR DESCRIPTION
Modified .dll and .pdb are placed in windebug subfolder.

Fixes git-for-windows/git#356

Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>