### PR TITLE
Revert "msys2-runtime-devel: bundle .pdb instead of .dbg files"

### DIFF
--- a/msys2-runtime/0058-fixup-Generate-a-.pdb-file-instead-of-a-.dbg-file.patch
+++ b/msys2-runtime/0058-fixup-Generate-a-.pdb-file-instead-of-a-.dbg-file.patch
@@ -1,0 +1,59 @@
+From 079350d03e90d3b910cab6d6521e65904927ed6b Mon Sep 17 00:00:00 2001
+From: Dakota Hawkins <dakotahawkins@gmail.com>
+Date: Sun, 22 Jul 2018 11:25:48 -0400
+Subject: [PATCH 58/N] fixup! Generate a .pdb file instead of a .dbg file
+
+Revert "Generate a .pdb file instead of a .dbg file"
+
+This reverts commit 36aa0d34eef28b063ad70813f2b5fcb862ab6b18.
+
+Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>
+---
+ winsup/cygwin/Makefile.in | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/winsup/cygwin/Makefile.in b/winsup/cygwin/Makefile.in
+index 315ef7c..ebb92e6 100644
+--- a/winsup/cygwin/Makefile.in
++++ b/winsup/cygwin/Makefile.in
+@@ -592,7 +592,7 @@ install-libs: $(TARGET_LIBS)
+ 	for i in $^; do \
+ 	    $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/lib/`basename $$i` ; \
+ 	done
+-	$(INSTALL_DATA) msys-2.0.pdb $(DESTDIR)$(bindir)/msys-2.0.pdb
++	$(INSTALL_DATA) msys-2.0.dbg $(DESTDIR)$(bindir)/msys-2.0.dbg
+ 	cd $(DESTDIR)$(tooldir)/lib && ln -sf libmsys-2.0.a libg.a
+ 
+ install-headers:
+@@ -658,7 +658,7 @@ uninstall-man:
+ 	done
+ 
+ clean distclean realclean:
+-	-rm -f *.o *.dll *.pdb *.a *.exp junk *.base version.cc *.exe *.d *stamp* *_magic.h sigfe.s msys.def globals.h
++	-rm -f *.o *.dll *.dbg *.a *.exp junk *.base version.cc *.exe *.d *stamp* *_magic.h sigfe.s msys.def globals.h
+ 	-@$(MAKE) -C ${cygserver_blddir} libclean
+ 
+ maintainer-clean: clean
+@@ -672,7 +672,7 @@ $(LDSCRIPT): $(LDSCRIPT).in
+ 	$(CC) -E - -P < $^ -o $@
+ 
+ # Rule to build msys-2.0.dll
+-$(TEST_DLL_NAME): $(LDSCRIPT) $(DLL_OFILES) $(LIBSERVER) $(LIBC) $(LIBM) $(API_VER) Makefile $(VERSION_OFILES)
++$(TEST_DLL_NAME): $(LDSCRIPT) dllfixdbg $(DLL_OFILES) $(LIBSERVER) $(LIBC) $(LIBM) $(API_VER) Makefile $(VERSION_OFILES)
+ 	$(CXX) $(CXXFLAGS) \
+ 	-mno-use-libstdc-wrappers -L${WINDOWS_LIBDIR} \
+ 	-Wl,--gc-sections $(nostdlib) -Wl,-T$(firstword $^) -static \
+@@ -680,9 +680,7 @@ $(TEST_DLL_NAME): $(LDSCRIPT) $(DLL_OFILES) $(LIBSERVER) $(LIBC) $(LIBM) $(API_V
+ 	-e $(DLL_ENTRY) $(DEF_FILE) $(DLL_OFILES) $(VERSION_OFILES) \
+ 	$(MALLOC_OBJ) $(LIBSERVER) $(LIBM) $(LIBC) \
+ 	-lgcc $(DLL_IMPORTS) -Wl,-Map,msys.map
+-	MINGW_PREFIX=/mingw32 && \
+-	case "$$(uname -m)" in x86_64) MINGW_PREFIX=/mingw64;; esac && \
+-	$$MINGW_PREFIX/bin/cv2pdb "$@" "$@" ${patsubst %0.dll,%-2.0.pdb,$@}
++	@$(word 2,$^) $(OBJDUMP) $(OBJCOPY) $@ ${patsubst %0.dll,%-2.0.dbg,$@}
+ 	@ln -f $@ new-$(DLL_NAME)
+ 
+ # Rule to build libmsys-2.0.a
+-- 
+2.9.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -21,8 +21,7 @@ makedepends=('cocom'
              'zlib-devel'
              'gettext-devel'
              'libiconv-devel'
-             'diffutils'
-             "mingw-w64-$(uname -m)-cv2pdb")
+             'diffutils')
 # options=('debug' '!strip')
 source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release
         0001-Add-MSYS-triplets.patch
@@ -81,7 +80,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0054-fixup-kill-kill-Win32-processes-more-gently.patch
         0055-srandomdev-avoid-warning-about-uninitialized-use.patch
         0056-squash-Fix-incorrect-path-conversion-trailing-slash.patch
-        0057-Cygwin-Fixing-the-math-behind-rounding-down-ch.stack.patch)
+        0057-Cygwin-Fixing-the-math-behind-rounding-down-ch.stack.patch
+        0058-fixup-Generate-a-.pdb-file-instead-of-a-.dbg-file.patch)
 sha256sums=('SKIP'
             '2a77753affdcf800acf208cb50f5c8008a7ea868209a6871247a7b2228685e0d'
             '0ce1b1cc6ce1a98fa07be518b0c7b2a005a5e22910f3c3fe7f7ff7bb59bafb98'
@@ -139,7 +139,8 @@ sha256sums=('SKIP'
             '87d1f0e9d3b4ebdbcffe64d27e7c1f32220cf5d74a681ac1a8dadbc057224378'
             '3ec38f7710402051360a2487c1d3783aff9dae2541e2feafb0074a7e9a618888'
             'b977786a27ecfe12d1211f4c21368ef57738b027b20910c830bfad3ff2879aba'
-            '40d8b815a9325e0d3253c9ac5d402556235a9e43b874fa1c587798b743f3d9c2')
+            '40d8b815a9325e0d3253c9ac5d402556235a9e43b874fa1c587798b743f3d9c2'
+            'c3e92c063fe0a99ca2e30c78f7d022a08012278267c04406ccd8f2e97c168700')
 
 # Helper macro to help make tasks easier #
 del_file_exists() {
@@ -212,6 +213,7 @@ prepare() {
   git am --committer-date-is-author-date "${srcdir}"/0055-srandomdev-avoid-warning-about-uninitialized-use.patch
   git am --committer-date-is-author-date "${srcdir}"/0056-squash-Fix-incorrect-path-conversion-trailing-slash.patch
   git am --committer-date-is-author-date "${srcdir}"/0057-Cygwin-Fixing-the-math-behind-rounding-down-ch.stack.patch
+  git am --committer-date-is-author-date "${srcdir}"/0058-fixup-Generate-a-.pdb-file-instead-of-a-.dbg-file.patch
 }
 
 build() {
@@ -257,7 +259,7 @@ package_msys2-runtime() {
 
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
-  rm -f "${pkgdir}"/usr/bin/msys-2.0.pdb
+  rm -f "${pkgdir}"/usr/bin/msys-2.0.dbg
   rm -f "${pkgdir}"/usr/bin/cyglsa-config
   rm -f "${pkgdir}"/usr/bin/cyglsa.dll
   rm -f "${pkgdir}"/usr/bin/cyglsa64.dll
@@ -275,7 +277,7 @@ package_msys2-runtime-devel() {
   replaces=('libcatgets-devel')
 
   mkdir -p "${pkgdir}"/usr/bin
-  cp -f "${srcdir}"/dest/usr/bin/msys-2.0.pdb "${pkgdir}"/usr/bin/
+  cp -f "${srcdir}"/dest/usr/bin/msys-2.0.dbg "${pkgdir}"/usr/bin/
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/include "${pkgdir}"/usr/
   rm -f "${pkgdir}"/usr/include/iconv.h
   rm -f "${pkgdir}"/usr/include/unctrl.h


### PR DESCRIPTION
Fixes git-for-windows/git#356

This reverts commit c8e710e5525f29abaf8cd18d5e8851133faf9035.

Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>

Supersedes #26 