### PR TITLE
Fix msys2 runtime update patches

### DIFF
--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -25,8 +25,23 @@ git -C src/msys2-runtime fetch --no-tags "$source_url" "$base_tag:$base_tag"
 merging_rebase_start="$(git -C src/msys2-runtime \
     rev-parse --verify --quiet HEAD^{/Start.the.merging.rebase})"
 
-git -c core.abbrev=7 -C src/msys2-runtime format-patch -o ../.. --signature=2.9.0 \
-	$base_tag.. ${merging_rebase_start:+^$merging_rebase_start} ||
+git -c core.abbrev=7 \
+	-c diff.renames=true \
+	-c format.from=false \
+	-c format.numbered=auto \
+	-c format.useAutoBase=false \
+	-C src/msys2-runtime \
+	format-patch \
+		--diff-algorithm=default \
+		--no-attach \
+		--no-add-header \
+		--no-cover-letter \
+		--no-thread \
+		--suffix=.patch \
+		--subject-prefix=PATCH \
+		--signature=2.9.0 \
+		--output-directory ../.. \
+			$base_tag.. ${merging_rebase_start:+^$merging_rebase_start} ||
 die "Could not generate new patch set"
 
 patches="$(ls 0*.patch)" &&

--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -8,8 +8,6 @@ die () {
 cd "$(dirname "$0")" ||
 die "Could not cd to msys2-runtime/"
 
-base_tag=refs/tags/cygwin-"$(sed -ne 'y/./_/' -e 's/^pkgver=//p' <PKGBUILD)"-release
-
 git rev-parse --verify HEAD >/dev/null &&
 git update-index -q --ignore-submodules --refresh &&
 git diff-files --quiet --ignore-submodules &&
@@ -18,6 +16,11 @@ die "Clean worktree required"
 
 git rm 0*.patch ||
 die "Could not remove previous patches"
+
+base_tag=refs/tags/cygwin-"$(sed -ne 'y/./_/' -e 's/^pkgver=//p' <PKGBUILD)"-release
+source_url=$(sed -ne 's/^source=\([^:]\+::\)\?["'\'']\?\([^"'\''#?=&,;[:space:]]\+[^)"'\''#?=&,;[:space:]]\).*/\2/p' <PKGBUILD)
+
+git -C src/msys2-runtime fetch --no-tags "$source_url" "$base_tag:$base_tag"
 
 merging_rebase_start="$(git -C src/msys2-runtime \
     rev-parse --verify --quiet HEAD^{/Start.the.merging.rebase})"

--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -19,8 +19,11 @@ die "Clean worktree required"
 git rm 0*.patch ||
 die "Could not remove previous patches"
 
+merging_rebase_start="$(git -C src/msys2-runtime \
+    rev-parse --verify --quiet HEAD^{/Start.the.merging.rebase})"
+
 git -c core.abbrev=7 -C src/msys2-runtime format-patch -o ../.. --signature=2.9.0 \
-	$base_tag.. ^HEAD^{/Start.the.merging.rebase} ||
+	$base_tag.. ${merging_rebase_start:+^$merging_rebase_start} ||
 die "Could not generate new patch set"
 
 patches="$(ls 0*.patch)" &&


### PR DESCRIPTION
Supersedes #25 and #28 

- Handle the case that `^HEAD^{/Start.the.merging.rebase}` doesn't match anything by checking before calling format-patch.
- Fetch $base_tag from the package source repo (by url) to make sure it exists and isn't stale.
- On one computer I have `diff.algorithm = patience` set in my ~/.gitconfig, and as a result `msys2-runtime/update-patches.sh` Updated a single old patch (0053, at present).

  The diff looked significant, and it took me a long long time to realizes it was just different context around changes.

  Calling `git format-patch` with relevant `-c` config defaults along with some `format-patch` options that reflect defaults should remedy this most of the time.