### PR TITLE
gnupg: enable drive letters support (#1869)

### DIFF
--- a/gnupg/0001-gnupg-2.2.9-have-drive-letters.patch
+++ b/gnupg/0001-gnupg-2.2.9-have-drive-letters.patch
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index 2a8372f..daefbc1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -641,6 +641,10 @@ use_ldapwrapper=yes
+ mmap_needed=yes
+ require_pipe_to_unblock_pselect=yes
+ case "${host}" in
++    *-msys*)
++        AC_DEFINE(HAVE_DRIVE_LETTERS,1,
++                  [Defined if the OS supports drive letters.])
++        ;;
+     *-mingw32*)
+         # special stuff for Windoze NT
+         ac_cv_have_dev_random=no

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gnupg
 pkgver=2.2.9
-pkgrel=1
+pkgrel=2
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
 url='https://gnupg.org/'
@@ -46,10 +46,12 @@ depends=('bzip2'
          'zlib'
         )
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
-        'gnupg-2.2.8-msys2.patch')
+        'gnupg-2.2.8-msys2.patch'
+        '0001-gnupg-2.2.9-have-drive-letters.patch')
 sha256sums=('6278eaabffa1ebc9fa2ceb3dc53eea9a1505ab02a668a86dd6fec06951af2164'
             'SKIP'
-            'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9')
+            'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9'
+            'bf9d6675024fa21003f48fc706a5f80799362b7370db0a6de19be36cf73919a5')
 validpgpkeys=('031EC2536E580D8EA286A9F22071B08A33BD3F06')
 install=${pkgname}.install
 
@@ -57,8 +59,9 @@ prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   sed '/noinst_SCRIPTS = gpg-zip/c sbin_SCRIPTS += gpg-zip' -i tools/Makefile.in
   patch -p1 -i ${srcdir}/gnupg-2.2.8-msys2.patch
+  patch -p1 -i ${srcdir}/0001-gnupg-2.2.9-have-drive-letters.patch
 
-  ./autogen.sh --force
+  autoreconf -fiv
 
   sed 's/development_version=yes/development_version=no/' -i configure
 }


### PR DESCRIPTION
Fix the absolute path expansion of Windows paths for --homedir and similar.