### PR TITLE
Add CI and prepare for gnupg v2.2.28

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+
+# AppVeyor and Drone Continuous Integration for MSYS2
+# Author: Renato Silva <br.renatosilva@gmail.com>
+# Author: Qian Hong <fracting@gmail.com>
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+# Configure
+source "$DIR/ci-library.sh"
+mkdir artifacts
+git_config user.email 'ci@msys2.org'
+git_config user.name  'MSYS2 Continuous Integration'
+git remote add upstream 'https://github.com/MSYS2/MSYS2-packages'
+git fetch --quiet upstream
+# reduce time required to install packages by disabling pacman's disk space checking
+sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
+
+pacman --noconfirm -Fy
+
+# Detect
+list_commits  || failure 'Could not detect added commits'
+list_packages || failure 'Could not detect changed files'
+message 'Processing changes' "${commits[@]}"
+test -z "${packages}" && success 'No changes in package recipes'
+define_build_order || failure 'Could not determine build order'
+
+# Build
+message 'Building packages' "${packages[@]}"
+execute 'Approving recipe quality' check_recipe_quality
+
+message 'Building packages'
+for package in "${packages[@]}"; do
+    echo "::group::[build] ${package}"
+    execute 'Fetch keys' "$DIR/fetch-validpgpkeys.sh"
+    execute 'Building binary' makepkg --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild
+    execute 'Building source' makepkg --noconfirm --noprogressbar --allsource
+    echo "::endgroup::"
+
+    echo "::group::[install] ${package}"
+    grep -qFx "${package}" "$(dirname "$0")/ci-dont-install-list.txt" || execute 'Installing' yes:pacman --noprogressbar --upgrade '*.pkg.tar.*'
+    echo "::endgroup::"
+
+    echo "::group::[diff] ${package}"
+    cd "$package"
+    for pkg in *.pkg.tar.*; do
+        message "File listing diff for ${pkg}"
+        pkgname="$(echo "$pkg" | rev | cut -d- -f4- | rev)"
+        diff -Nur <(pacman -Fl "$pkgname" | sed -e 's|^[^ ]* |/|' | sort) <(pacman -Ql "$pkgname" | sed -e 's|^[^/]*||' | sort) || true
+    done
+    cd - > /dev/null
+    echo "::endgroup::"
+
+    echo "::group::[dll check] ${package}"
+    execute 'Checking dll depencencies' list_dll_deps ./pkg
+    execute 'Checking dll bases' list_dll_bases ./pkg
+    echo "::endgroup::"
+
+    mv "${package}"/*.pkg.tar.* artifacts
+    mv "${package}"/*.src.tar.* artifacts
+    unset package
+done
+success 'All packages built successfully'
+
+cd artifacts
+execute 'SHA-256 checksums' sha256sum *

--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -2,18 +2,19 @@
 
 set -e
 
-# AppVeyor and Drone Continuous Integration for MSYS2
+# GitHub workflow for Git for Windows' Continuous Integration
 # Author: Renato Silva <br.renatosilva@gmail.com>
 # Author: Qian Hong <fracting@gmail.com>
+# Author: Johannes Schindelin <johannes.schindelin@gmx.de>
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 # Configure
 source "$DIR/ci-library.sh"
 mkdir artifacts
-git_config user.email 'ci@msys2.org'
-git_config user.name  'MSYS2 Continuous Integration'
-git remote add upstream 'https://github.com/MSYS2/MSYS2-packages'
+git_config user.email 'ci@github'
+git_config user.name  'Git for Windows Continuous Integration'
+git remote add upstream 'https://github.com/git-for-windows/MSYS2-packages'
 git fetch --quiet upstream
 # reduce time required to install packages by disabling pacman's disk space checking
 sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
@@ -25,7 +26,6 @@ list_commits  || failure 'Could not detect added commits'
 list_packages || failure 'Could not detect changed files'
 message 'Processing changes' "${commits[@]}"
 test -z "${packages}" && success 'No changes in package recipes'
-define_build_order || failure 'Could not determine build order'
 
 # Build
 message 'Building packages' "${packages[@]}"

--- a/.ci/ci-dont-install-list.txt
+++ b/.ci/ci-dont-install-list.txt
@@ -1,0 +1,2 @@
+msys2-runtime
+bash

--- a/.ci/ci-library.sh
+++ b/.ci/ci-library.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Continuous Integration Library for MSYS2
+# Continuous Integration Library for MSYS2/Git for Windows
 # Author: Renato Silva <br.renatosilva@gmail.com>
 # Author: Qian Hong <fracting@gmail.com>
+# Author: Johannes Schindelin <johannes.schindelin@gmx.de>
 
 # Enable colors
 normal=$(tput sgr0)
@@ -40,13 +41,13 @@ _as_list() {
     return "${result}"
 }
 
-# Changes since master or from head
+# Changes since main or from HEAD
 _list_changes() {
     local list_name="${1}"
     local filter="${2}"
     local strip="${3}"
     local git_options=("${@:4}")
-    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" upstream/master.. | sort -u)" ||
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" upstream/main.. | sort -u)" ||
     _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" HEAD^.. | sort -u)"
 }
 

--- a/.ci/ci-library.sh
+++ b/.ci/ci-library.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Continuous Integration Library for MSYS2
+# Author: Renato Silva <br.renatosilva@gmail.com>
+# Author: Qian Hong <fracting@gmail.com>
+
+# Enable colors
+normal=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+cyan=$(tput setaf 6)
+
+# Basic status function
+_status() {
+    local type="${1}"
+    local status="${package:+${package}: }${2}"
+    local items=("${@:3}")
+    case "${type}" in
+        failure) local -n nameref_color='red';   title='[MSYS2 CI] FAILURE:' ;;
+        success) local -n nameref_color='green'; title='[MSYS2 CI] SUCCESS:' ;;
+        message) local -n nameref_color='cyan';  title='[MSYS2 CI]'
+    esac
+    printf "\n${nameref_color}${title}${normal} ${status}\n\n"
+    printf "${items:+\t%s\n}" "${items:+${items[@]}}"
+}
+
+# Convert lines to array
+_as_list() {
+    local -n nameref_list="${1}"
+    local filter="${2}"
+    local strip="${3}"
+    local lines="${4}"
+    local result=1
+    nameref_list=()
+    while IFS= read -r line; do
+        test -z "${line}" && continue
+        result=0
+        [[ "${line}" = ${filter} ]] && nameref_list+=("${line/${strip}/}")
+    done <<< "${lines}"
+    return "${result}"
+}
+
+# Changes since master or from head
+_list_changes() {
+    local list_name="${1}"
+    local filter="${2}"
+    local strip="${3}"
+    local git_options=("${@:4}")
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" upstream/master.. | sort -u)" ||
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" HEAD^.. | sort -u)"
+}
+
+# Get package information
+_package_info() {
+    local package="${1}"
+    local properties=("${@:2}")
+    for property in "${properties[@]}"; do
+        local -n nameref_property="${property}"
+        nameref_property=($(
+            source "${package}/PKGBUILD"
+            declare -n nameref_property="${property}"
+            echo "${nameref_property[@]}"))
+    done
+}
+
+# Package provides another
+_package_provides() {
+    local package="${1}"
+    local another="${2}"
+    local pkgname provides
+    _package_info "${package}" pkgname provides
+    for pkg_name in "${pkgname[@]}";  do [[ "${pkg_name}" = "${another}" ]] && return 0; done
+    for provided in "${provides[@]}"; do [[ "${provided}" = "${another}" ]] && return 0; done
+    return 1
+}
+
+# Add package to build after required dependencies
+_build_add() {
+    local package="${1}"
+    local depends makedepends
+    for started_package in "${started_packages[@]}"; do
+        [[ "${started_package}" = "${package}" ]] && return 0
+    done
+    started_packages+=("${package}")
+    _package_info "${package}" depends makedepends
+    for dependency in "${depends[@]}" "${makedepends[@]}"; do
+        for unsorted_package in "${packages[@]}"; do
+            _package_provides "${unsorted_package}" "${dependency}" && _build_add "${unsorted_package}"
+        done
+    done
+    sorted_packages+=("${package}")
+}
+
+# Git configuration
+git_config() {
+    local name="${1}"
+    local value="${2}"
+    test -n "$(git config ${name})" && return 0
+    git config --global "${name}" "${value}" && return 0
+    failure 'Could not configure Git for makepkg'
+}
+
+# Run command with status
+execute(){
+    local status="${1}"
+    local command="${2}"
+    local arguments=("${@:3}")
+    cd "${package:-.}"
+    message "${status}"
+    if [[ "${command}" != *:* ]]
+        then ${command} ${arguments[@]}
+        else ${command%%:*} | ${command#*:} ${arguments[@]}
+    fi || failure "${status} failed"
+    cd - > /dev/null
+}
+
+# Sort packages by dependency
+define_build_order() {
+    local sorted_packages=()
+    for unsorted_package in "${packages[@]}"; do
+        _build_add "${unsorted_package}"
+    done
+    packages=("${sorted_packages[@]}")
+}
+
+# Added commits
+list_commits()  {
+    _list_changes commits '*' '#*::' --pretty=format:'%ai::[%h] %s'
+}
+
+# Changed recipes
+list_packages() {
+    local _packages
+    _list_changes _packages '*/PKGBUILD' '%/PKGBUILD' --pretty=format: --name-only || return 1
+    for _package in "${_packages[@]}"; do
+        local find_case_sensitive="$(find -name "${_package}" -type d -print -quit)"
+        test -n "${find_case_sensitive}" && packages+=("${_package}")
+    done
+    return 0
+}
+
+# Recipe quality
+check_recipe_quality() {
+    # TODO: remove this option when not anymore needed
+    if test -n "${DISABLE_QUALITY_CHECK}"; then
+        echo 'This feature is disabled.'
+        return 0
+    fi
+    saneman --format='\t%l:%c %p:%c %m' --verbose --no-terminal "${packages[@]}"
+}
+
+# List DDL dependencies
+list_dll_deps(){
+    local target="${1}"
+    echo "$(tput setaf 2)MSYS2 DLL dependencies:$(tput sgr0)"
+    find "$target" -regex ".*\.\(exe\|dll\)" -print0 | xargs -0 -r ldd | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
+    || echo "        None"
+}
+
+list_dll_bases(){
+    local target="${1}"
+    echo "$(tput setaf 2)MSYS2 DLL bases:$(tput sgr0)"
+    find "$target" -regex ".*\.\(exe\|dll\)" -print | rebase -iT - | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
+    || echo "        None"
+}
+
+# Status functions
+failure() { local status="${1}"; local items=("${@:2}"); _status failure "${status}." "${items[@]}"; exit 1; }
+success() { local status="${1}"; local items=("${@:2}"); _status success "${status}." "${items[@]}"; exit 0; }
+message() { local status="${1}"; local items=("${@:2}"); _status message "${status}"  "${items[@]}"; }

--- a/.ci/fetch-validpgpkeys.sh
+++ b/.ci/fetch-validpgpkeys.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. PKGBUILD
+
+set -e
+
+_keyserver=(
+    "keyserver.ubuntu.com"
+    "keys.gnupg.net"
+    "pgp.mit.edu"
+    "keys.openpgp.org"
+)
+for key in "${validpgpkeys[@]}"; do
+    for server in "${_keyserver[@]}"; do
+        timeout 20 /usr/bin/gpg --keyserver "${server}" --recv "${key}" && break || true
+    done
+done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: main
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # needed to determine which packages to build
+      - uses: git-for-windows/setup-git-for-windows-sdk@v1
+        with:
+          flavor: full
+      - name: ensure that post-install scripts are run
+        shell: bash
+        run: bash -lc true
+      - name: CI-Build
+        shell: bash
+        run: .ci/ci-build.sh
+        env:
+          MSYSTEM: MSYS
+          MAKEFLAGS: -j5
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v2
+        with:
+          name: msys2-packages
+          path: artifacts/*.pkg.tar.*

--- a/gnupg/0002-gnupg-2.2.28compile-without-ldap.patch
+++ b/gnupg/0002-gnupg-2.2.28compile-without-ldap.patch
@@ -1,0 +1,39 @@
+From c8b2162c0e7eb42b74811b7ed225fa0f56be4083 Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Fri, 11 Jun 2021 10:30:02 +0900
+Subject: [PATCH] dirmngir: Fix build with --disable-ldap.
+
+* dirmngr/dirmngr.c (parse_rereadable_options) [USE_LDAP]:
+Conditionalize.
+
+--
+
+Reported-by: Phil Pennock
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ dirmngr/dirmngr.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/dirmngr/dirmngr.c b/dirmngr/dirmngr.c
+index 04fe9e238..6a818cabc 100644
+--- a/dirmngr/dirmngr.c
++++ b/dirmngr/dirmngr.c
+@@ -736,6 +736,7 @@ parse_rereadable_options (ARGPARSE_ARGS *pargs, int reread)
+     case oRecursiveResolver: enable_recursive_resolver (1); break;
+ 
+     case oLDAPServer:
++#if USE_LDAP
+       {
+         ldap_server_t server;
+         char *p;
+@@ -757,6 +758,7 @@ parse_rereadable_options (ARGPARSE_ARGS *pargs, int reread)
+             opt.ldapservers = server;
+           }
+       }
++#endif
+       break;
+ 
+     case oKeyServer:
+-- 
+2.11.0
+

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=gnupg
-pkgver=2.2.27
-pkgrel=1
+pkgver=2.2.28
+pkgrel=0
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 provides=('dirmngr' "gnupg2=${pkgver}")
 url='https://gnupg.org/'
@@ -47,11 +47,13 @@ depends=('bzip2'
         )
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
         'gnupg-2.2.8-msys2.patch'
-        '0001-gnupg-2.2.9-have-drive-letters.patch')
-sha256sums=('34e60009014ea16402069136e0a5f63d9b65f90096244975db5cea74b3d02399'
+        '0001-gnupg-2.2.9-have-drive-letters.patch'
+        '0002-gnupg-2.2.28compile-without-ldap.patch')
+sha256sums=('6ff891fc7583a9c3fb9f097ee0d1de0a12469d4b53997e7ba5064950637dfaec'
             'SKIP'
             'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9'
-            'bf9d6675024fa21003f48fc706a5f80799362b7370db0a6de19be36cf73919a5')
+            'bf9d6675024fa21003f48fc706a5f80799362b7370db0a6de19be36cf73919a5'
+            '5a4e9dbc453d472eab0d0b450d2ce259038871940461a9feb07b6f0a2032550c')
 validpgpkeys=('031EC2536E580D8EA286A9F22071B08A33BD3F06'
               'D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '6DAA6E64A76D2840571B4902528897B826403ADA')
@@ -62,6 +64,7 @@ prepare() {
   sed '/noinst_SCRIPTS = gpg-zip/c sbin_SCRIPTS += gpg-zip' -i tools/Makefile.in
   patch -p1 -i ${srcdir}/gnupg-2.2.8-msys2.patch
   patch -p1 -i ${srcdir}/0001-gnupg-2.2.9-have-drive-letters.patch
+  patch -p1 -i ${srcdir}/0002-gnupg-2.2.28compile-without-ldap.patch
 
   autoreconf -fiv
 


### PR DESCRIPTION
To avoid having to put together a setup with the usual pacman related tools, this PR first adds a build definition to be run via GitHub Actions, and then adds a patch required to build [GNU Privacy Guard v2.2.28](https://github.com/gpg/gnupg/releases/tag/gnupg-2.2.28).