### PR TITLE
Allow building GNU Privacy Guard's dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         run: bash -lc true
       - name: CI-Build
         shell: bash
-        run: .ci/ci-build.sh
+        run: bash -l .ci/ci-build.sh
         env:
           MSYSTEM: MSYS
           MAKEFLAGS: -j5

--- a/libgcrypt/PKGBUILD
+++ b/libgcrypt/PKGBUILD
@@ -18,7 +18,7 @@ source=(https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2
 sha256sums=('97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd'
             '3a420cc2b238203b1d107bb20313bfdaa79f8a1358678a2f222093223132038c'
             'ffa8d8dcb6193ff85f8f978625f24e589985dbe22e1858af9b52cd141a76052f'
-            'cd7f58dc81a13328e34e0de8c6011196b5a2aa61b69dd611d4d7579ebf6cbb32')
+            '3339e6d9e3e1558eaff05c7adf6f0d3660590e84c3e9b5645543d464233ee270')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/libgcrypt/PKGBUILD
+++ b/libgcrypt/PKGBUILD
@@ -14,11 +14,13 @@ options=('!emptydirs')
 source=(https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2
         libgcrypt-1.7.3-ecc-test-fix.patch
         libgcrypt-1.8.0-use-poll.patch
-        libgcrypt-1.6.1-msys2.patch)
+        libgcrypt-1.6.1-msys2.patch
+        fix-broken-mlock-detection.patch)
 sha256sums=('97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd'
             '3a420cc2b238203b1d107bb20313bfdaa79f8a1358678a2f222093223132038c'
             'ffa8d8dcb6193ff85f8f978625f24e589985dbe22e1858af9b52cd141a76052f'
-            '3339e6d9e3e1558eaff05c7adf6f0d3660590e84c3e9b5645543d464233ee270')
+            '3339e6d9e3e1558eaff05c7adf6f0d3660590e84c3e9b5645543d464233ee270'
+            '21b64825594419ee1eaa7c0e680cc5c7ecb73671611e1d7c1db5cb4bf146d29e')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
@@ -26,6 +28,7 @@ prepare() {
   patch -p1 -i ${srcdir}/libgcrypt-1.7.3-ecc-test-fix.patch
   patch -p1 -i ${srcdir}/libgcrypt-1.8.0-use-poll.patch
   patch -p1 -i ${srcdir}/libgcrypt-1.6.1-msys2.patch
+  patch -p1 -i ${srcdir}/fix-broken-mlock-detection.patch
 
   autoreconf -fi
 }

--- a/libgcrypt/fix-broken-mlock-detection.patch
+++ b/libgcrypt/fix-broken-mlock-detection.patch
@@ -1,0 +1,58 @@
+From 709e55f11d7748977063a1ea9cd082777321feb5 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 15 Jun 2021 14:52:20 +0200
+Subject: [PATCH] Fix broken mlock detection
+
+We need to be careful when casting a pointer to a `long int`: the
+highest bit might be set, in which case the result is a negative number.
+
+In this instance, it is fatal: we now take the modulus of that negative
+number with regards to the page size, and subtract it from the page
+size. So what should be a number that is smaller than the page size is
+now larger than the page size.
+
+As a consequence, we do not try to lock a 4096-byte block that is at the
+page size boundary inside a `malloc()`ed block, but we try to do that
+_outside_ the block.
+
+Which means that we are not at all detecting whether `mlock()` is
+broken.
+
+Let's be very careful to case the pointer to an _unsigned_ value
+instead.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ acinclude.m4 | 2 +-
+ configure    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 3c8dfba..4a2a83c 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -236,7 +236,7 @@ int main()
+     pool = malloc( 4096 + pgsize );
+     if( !pool )
+         return 2;
+-    pool += (pgsize - ((long int)pool % pgsize));
++    pool += (pgsize - ((unsigned long int)pool % pgsize));
+ 
+     err = mlock( pool, 4096 );
+     if( !err || errno == EPERM || errno == EAGAIN)
+diff --git a/configure b/configure
+index 4722cfb..68b08ee 100755
+--- a/configure
++++ b/configure
+@@ -18028,7 +18028,7 @@ int main()
+     pool = malloc( 4096 + pgsize );
+     if( !pool )
+         return 2;
+-    pool += (pgsize - ((long int)pool % pgsize));
++    pool += (pgsize - ((unsigned long int)pool % pgsize));
+ 
+     err = mlock( pool, 4096 );
+     if( !err || errno == EPERM || errno == EAGAIN)
+-- 
+2.26.2
+

--- a/libgcrypt/libgcrypt-1.6.1-msys2.patch
+++ b/libgcrypt/libgcrypt-1.6.1-msys2.patch
@@ -1,7 +1,17 @@
 diff -Naur libgcrypt-1.6.1-orig/build-aux/config.guess libgcrypt-1.6.1/build-aux/config.guess
 --- libgcrypt-1.6.1-orig/build-aux/config.guess	2014-01-12 15:19:50.000000000 +0400
 +++ libgcrypt-1.6.1/build-aux/config.guess	2014-02-01 14:51:00.436300000 +0400
-@@ -866,6 +866,9 @@
+@@ -845,6 +845,9 @@ EOF
+     i*:CYGWIN*:*)
+ 	echo ${UNAME_MACHINE}-pc-cygwin
+ 	exit ;;
++    i*:MSYS*:*)
++	echo ${UNAME_MACHINE}-pc-msys
++	exit ;;
+     *:MINGW64*:*)
+ 	echo ${UNAME_MACHINE}-pc-mingw64
+ 	exit ;;
+@@ -891,6 +894,9 @@ EOF
      amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
  	echo x86_64-unknown-cygwin
  	exit ;;

--- a/libgpg-error/PKGBUILD
+++ b/libgpg-error/PKGBUILD
@@ -2,25 +2,33 @@
 
 pkgbase=libgpg-error
 pkgname=('libgpg-error' 'libgpg-error-devel') # 'gpg-error'
-pkgver=1.32
-pkgrel=1
+pkgver=1.42
+pkgrel=0
 pkgdesc="Support library for libgcrypt"
-arch=(i686 x86_64)
+arch=('i686' 'x86_64')
 url="https://gnupg.org"
 license=('LGPL')
-depends=('msys2-runtime' 'sh' 'libiconv' 'libintl')
+depends=('sh' 'libiconv' 'libintl')
 makedepends=('libiconv-devel' 'gettext-devel')
 source=(https://gnupg.org/ftp/gcrypt/libgpg-error/${pkgname}-${pkgver}.tar.bz2{,.sig}
-        libgpg-error-1.16-msys2.patch)
-sha256sums=('c345c5e73cc2332f8d50db84a2280abfb1d8f6d4f1858b9daa30404db44540ca'
+        libgpg-error-1.16-msys2.patch
+        gpg-error-static-linking.patch)
+sha256sums=('fc07e70f6c615f8c4f590a8e37a9b8dd2e2ca1e9408f8e60459c67452b925e23'
             'SKIP'
-            '8cba23cd11fe2344a692aceea1aeb6d0aeea7fa87ea11022500afdcd47c2fe93')
+            '9f24d6b26a9da60b14dba9ce8bb55110609ab5496ed969adfb07464c1393d678'
+            '9780e3e397b983ef52d5dae22d54c4453a47bddf04eafa2f874c75038e3485eb')
+#These might be signed by any of these keys https://gnupg.org/signature_key.html
+validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
+              '031EC2536E580D8EA286A9F22071B08A33BD3F06'
+              '5B80C5754298F0CB55D8ED6ABCEF7E294B092E28'
+              '6DAA6E64A76D2840571B4902528897B826403ADA')
 options=(!makeflags)
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
   patch -p1 -i ${srcdir}/libgpg-error-1.16-msys2.patch
+  patch -p1 -i ${srcdir}/gpg-error-static-linking.patch
   autoreconf -fi
 }
 

--- a/libgpg-error/gpg-error-static-linking.patch
+++ b/libgpg-error/gpg-error-static-linking.patch
@@ -1,0 +1,9 @@
+--- libgpg-error-1.37/src/gpg-error.pc.in.orig	2020-05-22 12:39:05.295785700 +0300
++++ libgpg-error-1.37/src/gpg-error.pc.in	2020-05-22 12:40:43.406658300 +0300
+@@ -11,5 +11,5 @@
+ Version: @PACKAGE_VERSION@
+ Cflags: @GPG_ERROR_CONFIG_CFLAGS@
+ Libs: @GPG_ERROR_CONFIG_LIBS@
+-Libs.private: @GPG_ERROR_CONFIG_LIBS_PRIVATE@
++Libs.private: @GPG_ERROR_CONFIG_LIBS_PRIVATE@ @LIBINTL@ @LIBICONV@
+ URL: https://www.gnupg.org/software/libgpg-error/index.html

--- a/libgpg-error/libgpg-error-1.16-msys2.patch
+++ b/libgpg-error/libgpg-error-1.16-msys2.patch
@@ -29,8 +29,8 @@ diff -Naur libgpg-error-1.16/build-aux/config.guess libgpg-error-1.16-msys2/buil
 +    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
 +	echo x86_64-unknown-msys
 +	exit ;;
-     p*:CYGWIN*:*)
- 	echo powerpcle-unknown-cygwin
+     prep*:SunOS:5.*:*)
+ 	echo powerpcle-unknown-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
  	exit ;;
 diff -Naur libgpg-error-1.16/build-aux/config.rpath libgpg-error-1.16-msys2/build-aux/config.rpath
 --- libgpg-error-1.16/build-aux/config.rpath	2013-02-25 12:53:36.000000000 +0400


### PR DESCRIPTION
Since MSYS2 stopped servicing their i686 flavor, Git for Windows has to take care of building all kinds of things that we formerly got "for free".

To build `gnupg`, we need an updated `libgcrypt`. For that, we need a newer `libgpg-error` (at least we _thought_ that we did). And to build `libgpg-error`, we need to switch from the `pkg-config` to the `pkgconf` package.

This PR allows us to do all that.