### PR TITLE
gnupg: fix smartcard support in 64-bit builds

### DIFF
--- a/gnupg/0003-scd-fix-for-SCARD_IO_REQUEST-structure.patch
+++ b/gnupg/0003-scd-fix-for-SCARD_IO_REQUEST-structure.patch
@@ -1,0 +1,40 @@
+From 1eb93d9229c54baa5f1b7ccf7d105d3692c51a4d Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Tue, 21 May 2019 16:18:36 +0900
+Subject: [PATCH] scd: Fix for SCARD_IO_REQUEST structure.
+
+* scd/apdu.c (struct pcsc_io_request_s): Use pcsc_dword_t for Windows.
+
+--
+
+This fix is for correctness and for the future when we will support
+64-bit Windows.
+
+GnuPG-bug-id: 4454
+Suggested-by: Juris Ozols
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ scd/apdu.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/scd/apdu.c b/scd/apdu.c
+index ffa28c689..254c74101 100644
+--- a/scd/apdu.c
++++ b/scd/apdu.c
+@@ -256,8 +256,13 @@ static npth_mutex_t reader_table_lock;
+ 
+ struct pcsc_io_request_s
+ {
++#if defined(_WIN32) || defined(__CYGWIN__)
++  pcsc_dword_t protocol;
++  pcsc_dword_t pci_len;
++#else
+   unsigned long protocol;
+   unsigned long pci_len;
++#endif
+ };
+ 
+ typedef struct pcsc_io_request_s *pcsc_io_request_t;
+-- 
+2.32.0.windows.2
+

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -48,12 +48,14 @@ depends=('bzip2'
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
         'gnupg-2.2.8-msys2.patch'
         '0001-gnupg-2.2.9-have-drive-letters.patch'
-        '0002-gnupg-2.2.28compile-without-ldap.patch')
+        '0002-gnupg-2.2.28compile-without-ldap.patch'
+        '0003-scd-Fix-for-SCARD_IO_REQUEST-structure.patch')
 sha256sums=('6ff891fc7583a9c3fb9f097ee0d1de0a12469d4b53997e7ba5064950637dfaec'
             'SKIP'
             'cb23f1a61fd213c25e85b6ba8afb190b7da14a8cfa59cc56ce82df941db8c3c9'
             'bf9d6675024fa21003f48fc706a5f80799362b7370db0a6de19be36cf73919a5'
-            '5a4e9dbc453d472eab0d0b450d2ce259038871940461a9feb07b6f0a2032550c')
+            '5a4e9dbc453d472eab0d0b450d2ce259038871940461a9feb07b6f0a2032550c'
+            'fe8c17bf1ab486f275e270048242d891881f733eda399f4a0acea36033f77df3')
 validpgpkeys=('031EC2536E580D8EA286A9F22071B08A33BD3F06'
               'D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '6DAA6E64A76D2840571B4902528897B826403ADA')
@@ -65,6 +67,7 @@ prepare() {
   patch -p1 -i ${srcdir}/gnupg-2.2.8-msys2.patch
   patch -p1 -i ${srcdir}/0001-gnupg-2.2.9-have-drive-letters.patch
   patch -p1 -i ${srcdir}/0002-gnupg-2.2.28compile-without-ldap.patch
+  patch -p1 -i ${srcdir}/0003-scd-Fix-for-SCARD_IO_REQUEST-structure.patch
 
   autoreconf -fiv
 


### PR DESCRIPTION
Working as you can see from the commit signature ;)

Fixes: git-for-windows/git#2888