### PR TITLE
bash: fix build in Git for Windows' i686 SDK

### DIFF
--- a/bash/PKGBUILD
+++ b/bash/PKGBUILD
@@ -12,8 +12,12 @@ arch=('i686' 'x86_64')
 license=('GPL')
 url="https://www.gnu.org/software/bash/bash.html"
 validpgpkeys=('7C0135FB088AAF6C66C650B9BB5869F064EA74AB') # Chet Ramey
-makedepends=('gettext-devel' 'libreadline-devel>=7.0' 'ncurses-devel' 'autotools' 'gcc'
+makedepends=('gettext-devel' 'libreadline-devel>=7.0' 'ncurses-devel' 'gcc'
              "mingw-w64-$(uname -m)-cv2pdb")
+if [ "${CARCH}" == 'x86_64' ]; then
+	# Git for Windows' i686-bit SDK does not have the `autotools` package
+	makedepends+=('autotools')
+fi
 source=(https://ftp.gnu.org/gnu/bash/bash-${_basever}.tar.gz{,.sig}
         0001-bash-4.4-cygwin.patch
         0002-bash-4.3-msysize.patch


### PR DESCRIPTION
This addresses https://github.com/git-for-windows/MSYS2-packages/pull/52#issuecomment-1050273853.