### PR TITLE
perl-Clone: sync with MSYS2

### DIFF
--- a/perl-Clone/PKGBUILD
+++ b/perl-Clone/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=Clone
+pkgname=perl-${_realname}
+pkgver=0.45
+pkgrel=2
+pkgdesc='Recursive copy of nested objects.'
+arch=('i686' 'x86_64')
+url='https://search.cpan.org/~RDF/Clone'
+groups=('perl-modules')
+license=('GPL' 'PerlArtistic')
+depends=('perl')
+makedepends=('perl-devel' 'gcc' 'make')
+options=('!emptydirs')
+source=("https://search.cpan.org/CPAN/authors/id/A/AT/ATOOMIC/${_realname}-${pkgver}.tar.gz")
+sha512sums=('4d91580fb60876cca7670411748e42e6af0eaba8fac25d60e7a50685ae7b1e697e12c8a2835693e3e4abf3c13c060a2740344eb804ec26ed274b895f599340af')
+
+build() {
+  ( export PERL_MM_USE_DEFAULT=1 PERL5LIB=""                 \
+      PERL_AUTOINSTALL=--skipdeps                            \
+      PERL_MM_OPT="INSTALLDIRS=vendor"     \
+      PERL_MB_OPT="--installdirs vendor" \
+      MODULEBUILDRC=/dev/null
+
+    cd ${_realname}-${pkgver}
+    /usr/bin/perl Makefile.PL
+    make
+  )
+}
+
+package() {
+  cd ${_realname}-${pkgver}
+  make DESTDIR="$pkgdir" install
+  find "$pkgdir" -name '.packlist' -delete
+  find "$pkgdir" -name '*.pod' -delete
+}


### PR DESCRIPTION
This is a dependency of perl-HTTP-Message, and it has a native component, which means that Git for Windows has to rebuild it every time Perl is upgraded to a new major version (because the version number is part of the `msys-perl5_$version.dll` file name).

This was reported by the [`check-for-missing-dlls.sh` script](https://github.com/git-for-windows/build-extra/blob/HEAD/check-for-missing-dlls.sh).