### PR TITLE
build-and-deploy: use a nicer display name

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,5 @@
 name: build-and-deploy
+run-name: Build${{ inputs.build_only == '' && ' and deploy' || '' }} ${{ inputs.package }} (${{ inputs.architecture }})
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
When "branch-deploying" packages (i.e. building and publishing packages from PR branches in preparation for merging the PRs), it is currently a bit tricky to know whether i686 and x86_64 flavors have shipped or not. For example, when branch-deploying `bash`, the runs [showed up in the checks](https://github.com/git-for-windows/MSYS2-packages/pull/64#event-7891123466) but gave no clue what was built (or whether the same flavor was built twice):

![image](https://user-images.githubusercontent.com/127790/203965214-2a02e80e-3cc1-4846-aefe-785c9d6d6d98.png)

The `run-name` feature [was recently shipped to help with that](https://github.blog/changelog/2022-09-26-github-actions-dynamic-names-for-workflow-runs/). Let's use it to make it much easier to understand what that particular workflow run is all about. Example: https://github.com/dscho/MSYS2-packages/actions/runs/3547255249