### PR TITLE
ci: use newer GitHub Actions' versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # needed to determine which packages to build
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
@@ -23,7 +23,7 @@ jobs:
           MSYSTEM: MSYS
           MAKEFLAGS: -j5
       - name: "Upload binaries"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: msys2-packages
           path: artifacts/*.pkg.tar.*


### PR DESCRIPTION
This avoids the loud deprecation warning about node.js 12:

	Annotations
	1 warning

	build
	Node.js 12 actions are deprecated. For more information see:
	https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
	Please update the following actions to use Node.js 16: [...]