### PR TITLE
less(i686): _actually_ link to PCRE2

### DIFF
--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -10,7 +10,7 @@ url="http://www.greenwoodsoftware.com/less"
 depends=('ncurses' 'libpcre2_8')
 makedepends=('ncurses-devel' 'pcre2-devel')
 source=("https://github.com/gwsw//${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('88920b41585dc3702a69064f498e599c209eda5b2d820e40d372a625b984dd83')
+sha256sums=('cfcc4537e8bbabe0783ccf53a302b7341547bc98be5d8c8771616768aeca30de')
 validpgpkeys=('AE27252BD6846E7D6EAE1DD6F153A7C833235259') # Mark Nudelman
 if [ "${CARCH}" == 'x86_64' ]; then
        # Git for Windows' i686-bit SDK does not have the `autotools` package

--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -31,7 +31,7 @@ build() {
       --build=${CHOST} \
       --prefix=/usr \
       --sysconfdir=/etc \
-      --with-regex=pcre
+      --with-regex=pcre2
   make
 }
 

--- a/less/PKGBUILD
+++ b/less/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=less
 pkgver=621
-pkgrel=1
+pkgrel=2
 pkgdesc="A terminal based program for viewing text files"
 license=('GPL3')
 arch=('i686' 'x86_64')


### PR DESCRIPTION
In 8e6d96af (less: align with MSYS2, 2023-01-26), we tried to align with MSYS2, and we even changed the `depends` and `makedepends` entries of the `PKGBUILD` file.

But we forgot to adjust the `./configure` call ;-)

As a result, Git for Windows' i686 version of `less.exe` (which is not provided by MSYS2 anymore) currently does not even support regular expressions...

This incidentally triggers a bug (hence fixed in `less`' main branch) where searching for any matching term would cause a segmentation fault.

So let's just let `less.exe` link to PCRE2 already.