### PR TITLE
Avoid sharing cygheap between msys2 runtime versions

### DIFF
--- a/msys2-runtime/0063-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+++ b/msys2-runtime/0063-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
@@ -1,0 +1,63 @@
+From 65ce633af3e55721eec16ae53a3100092d9de406 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 30 Jan 2023 23:22:22 +0100
+Subject: [PATCH 63/N] Avoid sharing cygheaps across Cygwin versions
+
+It frequently leads to problems when trying, say, to call from Git for
+Windows' Bash into Cygwin's or MSYS2's, merely because sharing that data
+is pretty finicky.
+
+For example, using the Git for Windows that is current at time of
+writing, trying to call MSYS2's Bash from Git for Windows' Bash fails
+somewhere in `_cmalloc()`, without any error message, and with the
+rather misleading exit code 127 (a code which is reserved to indicate
+that a command was not found).
+
+Let's just treat these as completely incompatible with one another, by
+virtue of using a different `CHILD_INFO_MAGIC` constant.
+
+One consequence is that spawned MSYS processes using a different MSYS2
+runtime will not be visible as such to the parent process, i.e. they
+cannot share any resources such as pseudo terminals. But that's okay,
+they are simply treated as if they were regular Win32 programs.
+
+This should also help the scenario where interactions between two
+different versions of Git for Windows lead to those infamous `cygheap
+base mismatch detected` problems mentioned e.g. in
+https://github.com/git-for-windows/git/issues/4255
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/cygwin/dcrt0.cc   | 2 +-
+ winsup/cygwin/sigproc.cc | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
+index e32f02b..45f3b0f 100644
+--- a/winsup/cygwin/dcrt0.cc
++++ b/winsup/cygwin/dcrt0.cc
+@@ -545,7 +545,7 @@ get_cygwin_startup_info ()
+   child_info *res = (child_info *) si.lpReserved2;
+ 
+   if (si.cbReserved2 < EXEC_MAGIC_SIZE || !res
+-      || res->intro != PROC_MAGIC_GENERIC || res->magic != CHILD_INFO_MAGIC)
++      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ CYGWIN_VERSION_DLL_COMBINED))
+     {
+       strace.activate (false);
+       res = NULL;
+diff --git a/winsup/cygwin/sigproc.cc b/winsup/cygwin/sigproc.cc
+index fbb1f0e..65dc523 100644
+--- a/winsup/cygwin/sigproc.cc
++++ b/winsup/cygwin/sigproc.cc
+@@ -817,7 +817,7 @@ int child_info::retry_count = 0;
+    by fork/spawn/exec. */
+ child_info::child_info (unsigned in_cb, child_info_types chtype,
+ 			bool need_subproc_ready):
+-  cb (in_cb), intro (PROC_MAGIC_GENERIC), magic (CHILD_INFO_MAGIC),
++  cb (in_cb), intro (PROC_MAGIC_GENERIC), magic (CHILD_INFO_MAGIC ^ CYGWIN_VERSION_DLL_COMBINED),
+   type (chtype), cygheap (::cygheap), cygheap_max (::cygheap_max),
+   flag (0), retry (child_info::retry_count), rd_proc_pipe (NULL),
+   wr_proc_pipe (NULL), sigmask (_my_tls.sigmask)
+-- 
+2.9.0
+

--- a/msys2-runtime/0064-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
+++ b/msys2-runtime/0064-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
@@ -1,0 +1,50 @@
+From 4704d291696b2f2521aba2d05d08f69b01e2a455 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 31 Jan 2023 09:32:08 +0100
+Subject: [PATCH 64/N] dumper: avoid linker problem when `libbfd` depends on
+ `libsframe`
+
+A recent binutils version introduced `libsframe` and made it a
+dependency of `libbfd`. Which means that we have to link that library
+into `dumper.exe`, too, if it exists.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ winsup/configure.ac      | 5 +++++
+ winsup/utils/Makefile.am | 4 ++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/winsup/configure.ac b/winsup/configure.ac
+index 5eb3273..ca2b8c0 100644
+--- a/winsup/configure.ac
++++ b/winsup/configure.ac
+@@ -110,6 +110,11 @@ AC_CHECK_LIB([bfd], [bfd_init], [true],
+ 
+ AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
+ 
++AC_CHECK_LIB([sframe], [sframe_decode],
++	     AC_MSG_NOTICE([Detected libsframe; Assuming that libbfd depends on it]), [true])
++
++AM_CONDITIONAL(HAVE_LIBSFRAME, [test "x$ac_cv_lib_sframe_sframe_decode" = "xyes"])
++
+ AC_CONFIG_FILES([
+     Makefile
+     cygwin/Makefile
+diff --git a/winsup/utils/Makefile.am b/winsup/utils/Makefile.am
+index e12dfdd..08f6212 100644
+--- a/winsup/utils/Makefile.am
++++ b/winsup/utils/Makefile.am
+@@ -87,6 +87,10 @@ profiler_CXXFLAGS = -I$(srcdir) -idirafter ${top_srcdir}/cygwin -idirafter ${top
+ profiler_LDADD = $(LDADD) -lntdll
+ cygps_LDADD = $(LDADD) -lpsapi -lntdll
+ 
++if HAVE_LIBSFRAME
++dumper_LDADD += -lsframe
++endif
++
+ if CROSS_BOOTSTRAP
+ SUBDIRS = mingw
+ endif
+-- 
+2.9.0
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.3.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -86,7 +86,9 @@ source=('msys2-runtime'::git+https://github.com/cygwin/cygwin#tag=cygwin-${pkgve
         0059-Make-paths-WCS-MBS-conversion-explicit.patch
         0060-Use-MB_CUR_MAX-6-by-default.patch
         0061-Change-the-default-base-address-for-x86_64.patch
-        0062-Do-not-try-to-sync-with-Cygwin.patch)
+        0062-Do-not-try-to-sync-with-Cygwin.patch
+        0063-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+        0064-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch)
 sha256sums=('SKIP'
             '0113ee0d3bad78a0575b83e321d41d859b99140d9471762c8a82e766cae36c48'
             'ee1c4c5161eb977c48d02678069fb1836ce36a46b626a71b30ae3bc0fabf77c6'
@@ -149,7 +151,9 @@ sha256sums=('SKIP'
             'cba2181936051214a7218ee933cc9f3619e46b500fdaadfa69b7f38eefda3f10'
             '4809e399aead149f5106248196249130537de492d43e4ba95bfeded84305f39b'
             '5188dc6b44c58eb0140c9078f7bbdb999a228755ef449fa055f8c3415ed2baba'
-            '30f5b96b1fb1c22d0dd463d2ebd592d72650b20db4bc5fbf7dd7c2d81f6c29ce')
+            '30f5b96b1fb1c22d0dd463d2ebd592d72650b20db4bc5fbf7dd7c2d81f6c29ce'
+            '9559bbb33faf6773cd6439be05962a116184b945b909ba49049db3b7c3761a11'
+            'cd576bc86766e5df42af3ac5594073859e562e24ef01e7ab21f0d38ef4d87834')
 
 # Helper macro to help make tasks easier #
 del_file_exists() {
@@ -238,6 +242,8 @@ prepare() {
   git am --committer-date-is-author-date --ignore-space-change "${srcdir}"/0060-Use-MB_CUR_MAX-6-by-default.patch
   git am --committer-date-is-author-date --ignore-space-change "${srcdir}"/0061-Change-the-default-base-address-for-x86_64.patch
   git am --committer-date-is-author-date --ignore-space-change "${srcdir}"/0062-Do-not-try-to-sync-with-Cygwin.patch
+  git am --committer-date-is-author-date --ignore-space-change "${srcdir}"/0063-Avoid-sharing-cygheaps-across-Cygwin-versions.patch
+  git am --committer-date-is-author-date --ignore-space-change "${srcdir}"/0064-dumper-avoid-linker-problem-when-libbfd-depends-on-l.patch
 }
 
 build() {

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -24,7 +24,7 @@ makedepends=('cocom'
              'libiconv-devel'
              'diffutils')
 # options=('debug' '!strip')
-source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release
+source=('msys2-runtime'::git+https://github.com/cygwin/cygwin#tag=cygwin-${pkgver//./_}-release
         0001-Add-MSYS2-triplet.patch
         0002-Fix-msys-library-name-in-import-libraries.patch
         0003-Rename-dll-from-cygwin-to-msys.patch


### PR DESCRIPTION
This is a companion to https://github.com/git-for-windows/msys2-runtime/pull/48 and is designed to fix https://github.com/git-for-windows/git/issues/4255