### PR TITLE
docbook-xsl-ns: prepare for building an i686 version

### DIFF
--- a/docbook-xsl-ns/PKGBUILD
+++ b/docbook-xsl-ns/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+pkgname=docbook-xsl-ns
+pkgver=1.79.2
+pkgrel=2
+pkgdesc='XML stylesheets with namespaces for Docbook-xml transformations'
+arch=('any')
+license=('custom')
+url='https://github.com/docbook/xslt10-stylesheets'
+depends=('libxml2' 'libxslt')
+install="$pkgname.install"
+source=(${pkgname}-${pkgver}.tar.gz::${url}/releases/download/release/${pkgver}/${pkgname%-ns}-${pkgver}.tar.gz)
+sha256sums=('966188d7c05fc76eaca115a55893e643dd01a3486f6368733c9ad974fcee7a26')
+
+package() {
+  cd ${srcdir}/${pkgname%-ns}-${pkgver}
+
+  _pkgroot=${pkgdir}/usr/share/xml/docbook-xsl-ns/${pkgver}
+
+  install -dm755 ${_pkgroot}
+  cp -R * ${_pkgroot}/
+
+  rm ${_pkgroot}/{install.sh,build.xml} || true # ignore missing files
+
+  install -dm755 ${pkgdir}/etc/xml
+  install -Dm644 COPYING ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
+}

--- a/docbook-xsl-ns/docbook-xsl-ns.install
+++ b/docbook-xsl-ns/docbook-xsl-ns.install
@@ -1,0 +1,36 @@
+post_install() {
+  if [ ! -f etc/xml/catalog ]; then
+    usr/bin/xmlcatalog --noout --create etc/xml/catalog
+  fi
+  _NEW=`echo $1 | sed 's|\(.*\)\-.*|\1|'`
+
+  usr/bin/xmlcatalog --noout --add "rewriteSystem" \
+    "http://docbook.sourceforge.net/release/xsl-ns/${_NEW}" \
+    "/usr/share/xml/docbook-xsl-ns/${_NEW}" \
+    etc/xml/catalog
+
+  usr/bin/xmlcatalog --noout --add "rewriteURI" \
+    "http://docbook.sourceforge.net/release/xsl-ns/${_NEW}" \
+    "/usr/share/xml/docbook-xsl-ns/${_NEW}" \
+    etc/xml/catalog &&
+
+  usr/bin/xmlcatalog --noout --add "rewriteSystem" \
+    "http://docbook.sourceforge.net/release/xsl-ns/current" \
+    "/usr/share/xml/docbook-xsl-ns/${_NEW}" \
+    etc/xml/catalog &&
+
+  usr/bin/xmlcatalog --noout --add "rewriteURI" \
+    "http://docbook.sourceforge.net/release/xsl-ns/current" \
+    "/usr/share/xml/docbook-xsl-ns/${_NEW}" \
+    etc/xml/catalog
+}
+
+post_upgrade() {
+  post_remove $2
+  post_install $1
+}
+
+post_remove() {
+  _OLD=`echo $1 | sed 's|\(.*\)\-.*|\1|'`
+  usr/bin/xmlcatalog --noout --del "/usr/share/xml/docbook-xsl-ns/${_OLD}" etc/xml/catalog
+}


### PR DESCRIPTION
Now that Git for Windows is about to switch to the `git-sdk-32` to build the `mingw-w64-i686-git` package, we better have an i686 version of the prerequisite `docbook-xsl-ns` package, too.