### PR TITLE
Fix the i686 variant of the `libgpg error` package

### DIFF
--- a/libgpg-error/0003-Avoid-passing-a-signed-parameter-to-isspace-and-frie.patch
+++ b/libgpg-error/0003-Avoid-passing-a-signed-parameter-to-isspace-and-frie.patch
@@ -1,8 +1,8 @@
-From e19acaa56e27acaa9acdadff5f0a8fd0e3399c15 Mon Sep 17 00:00:00 2001
+From b67f56e4447c333317a1908472ea696502768e48 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Sun, 30 Apr 2023 12:51:32 +0200
-Subject: [PATCH 3/3] argparse: avoid passing a signed parameter to `isspace()`
- and friends
+Subject: [PATCH 3/3] Avoid passing a signed parameter to `isspace()` and
+ friends
 
 In Cygwin, the `isspace()` family of functions seem to be inline
 functions that directly access an array if the parameter is below a
@@ -19,9 +19,23 @@ Let's accommodate for that.
 
 Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
 ---
+ doc/yat2m.c    |  2 +-
  src/argparse.c | 24 ++++++++++++------------
- 1 file changed, 12 insertions(+), 12 deletions(-)
+ 2 files changed, 13 insertions(+), 13 deletions(-)
 
+diff --git a/doc/yat2m.c b/doc/yat2m.c
+index c2806e3..605e962 100644
+--- a/doc/yat2m.c
++++ b/doc/yat2m.c
+@@ -500,7 +500,7 @@ macro_set_p (const char *name)
+         break;
+   if (!m || !m->value || !*m->value)
+     return 0;
+-  if ((*m->value & 0x80) || !isdigit (*m->value))
++  if ((*m->value & 0x80) || !isdigit ((unsigned char)*m->value))
+     return 1; /* Not a digit but some other string.  */
+   return !!atoi (m->value);
+ }
 diff --git a/src/argparse.c b/src/argparse.c
 index 8651e00..394a908 100644
 --- a/src/argparse.c

--- a/libgpg-error/PKGBUILD
+++ b/libgpg-error/PKGBUILD
@@ -13,12 +13,12 @@ makedepends=('libiconv-devel' 'gettext-devel')
 source=(https://gnupg.org/ftp/gcrypt/libgpg-error/${pkgname}-${pkgver}.tar.bz2{,.sig}
         0001-gnulib-weak.patch
         0002-gpg-error-static-linking.patch
-        0003-argparse-avoid-passing-a-signed-parameter-to-isspace.patch)
+        0003-Avoid-passing-a-signed-parameter-to-isspace-and-frie.patch)
 sha256sums=('9e3c670966b96ecc746c28c2c419541e3bcb787d1a73930f5e5f5e1bcbbb9bdb'
             'SKIP'
             '8b716e8fb6ef7d4b9c5c730b5819556ed907cbb0b0a144062fa5f41a58d92da8'
             'a04b60374178755c9db848c5e050cccd038b20dd7b0c3cab3e27fbbcd6382484'
-            '9c65ed282a93cae2bac88c8cda93cfc0cc8642d693910b1825984b8e5aba41e9')
+            '3f23c42c424cdeb072769bf8748665da3155b5a172da08be22b641dd04827612')
 #These might be signed by any of these keys https://gnupg.org/signature_key.html
 validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '031EC2536E580D8EA286A9F22071B08A33BD3F06'
@@ -30,7 +30,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0001-gnulib-weak.patch
   patch -p1 -i ${srcdir}/0002-gpg-error-static-linking.patch
-  patch -p1 -i ${srcdir}/0003-argparse-avoid-passing-a-signed-parameter-to-isspace.patch
+  patch -p1 -i ${srcdir}/0003-Avoid-passing-a-signed-parameter-to-isspace-and-frie.patch
   autoreconf -fi
 }
 

--- a/libgpg-error/PKGBUILD
+++ b/libgpg-error/PKGBUILD
@@ -36,10 +36,9 @@ prepare() {
 
 build() {
   cd "${srcdir}"/${pkgname}-${pkgver}
-  local CYGWIN_CHOST="${CHOST/-msys/-cygwin}"
   ./configure \
     --prefix=/usr \
-    --build=${CYGWIN_CHOST} \
+    --build=${CHOST} \
     --without-libiconv-prefix \
     --without-libintl-prefix \
     --enable-install-gpg-error-config \

--- a/libgpg-error/PKGBUILD
+++ b/libgpg-error/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libgpg-error
 pkgname=('libgpg-error' 'libgpg-error-devel') # 'gpg-error'
 pkgver=1.47
-pkgrel=1
+pkgrel=2
 pkgdesc="Support library for libgcrypt"
 arch=('i686' 'x86_64')
 url="https://gnupg.org"


### PR DESCRIPTION
In #100, I deployed the i686 version of `libgpg_error` with a `.dll` whose file name incorrectly starts with `cyg` instead of `msys-`. This broke `gpg.exe` that depends on the correct file name.

I [temporarily prevented `git-sdk-32` from upgrading `libgpg-error`](https://github.com/git-for-windows/git-sdk-32/commit/57987349dfed17b7c0e2656908d8bf1f50564e79) just so that `libgpg-error` could be branch-deployed from _this_ PR, using the expected file name.