### PR TITLE
msys2-runtime-3.3: replace msys2-runtime in i686 setups

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -34,6 +34,11 @@ execute 'Approving recipe quality' check_recipe_quality
 
 message 'Building packages'
 for package in "${packages[@]}"; do
+    test msys2-runtime-3.3 != "${package}" || {
+        echo "Skipping ${package}: we only need to build this for i686" >&2
+        continue
+    }
+
     echo "::group::[build] ${package}"
     execute 'Fetch keys' "$DIR/fetch-validpgpkeys.sh"
     execute 'Building binary' makepkg --noconfirm --noprogressbar --nocheck --syncdeps --rmdeps --cleanbuild

--- a/msys2-runtime-3.3/PKGBUILD
+++ b/msys2-runtime-3.3/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime-3.3
 pkgname=('msys2-runtime-3.3' 'msys2-runtime-3.3-devel')
 pkgver=3.3.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686')
 url="https://www.cygwin.com/"

--- a/msys2-runtime-3.3/PKGBUILD
+++ b/msys2-runtime-3.3/PKGBUILD
@@ -298,6 +298,8 @@ package_msys2-runtime-3.3() {
   replaces=('catgets' 'libcatgets')
   #install=msys2-runtime.install
 
+  test i686-pc-msys != "$CHOST" || replaces+=('msys2-runtime')
+
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
   rm -f "${pkgdir}"/usr/bin/msys-2.0.dbg
@@ -317,6 +319,8 @@ package_msys2-runtime-3.3-devel() {
   options=('staticlibs' '!strip')
   conflicts=('libcatgets-devel' 'msys2-runtime-devel')
   replaces=('libcatgets-devel')
+
+  test i686-pc-msys != "$CHOST" || replaces+=('msys2-runtime-devel')
 
   mkdir -p "${pkgdir}"/usr/bin
   cp -f "${srcdir}"/dest/usr/bin/msys-2.0.dbg "${pkgdir}"/usr/bin/


### PR DESCRIPTION
With this change, i686 variants of the Git for Windows SDK will automatically be moved to the v3.3.* train, allowing msys2-runtime to upgrade to v3.4.* (which does not build on i686 anymore).