### PR TITLE
vim: align with MSYS2

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -1,11 +1,13 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: Francesco Corte <francesco.corte9001@gmail.com>
 
 pkgname=vim
-_topver=8.2
-_patchlevel=5117
+_topver=9.0
+_patchlevel=2121
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
-pkgrel=2
+pkgrel=1
+pkgdesc='Vi Improved, a highly configurable, improved version of the vi text editor'
 arch=('i686' 'x86_64')
 license=('custom:vim')
 url="https://www.vim.org"
@@ -13,7 +15,7 @@ depends=('ncurses' 'libiconv' 'libintl')
 groups=('editors')
 makedepends=('gawk' 'ncurses-devel' 'gcc'
              'libiconv-devel' 'gettext-devel') # To satisfy python3/dyn feature #3052
-source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgver}.tar.gz
+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgver}/${pkgbase}-{pkgver}.tar.gz
         'dot.vimrc'
         '7.3-cygwin-mouse.patch'
         '7.3-virc.patch'
@@ -21,7 +23,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('4d47aedd0b984f069ddf329c4a73a53b9b2c13b2806894fe3c2f47a98c6e6e8e'
+sha256sums=('8d04737e71f529b37f18ec26a16a11ef183bb83b214f4e6ddddf20136c5813ea'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'
@@ -31,7 +33,8 @@ sha256sums=('4d47aedd0b984f069ddf329c4a73a53b9b2c13b2806894fe3c2f47a98c6e6e8e'
             'bdca6069ef0fa995718f4b59fea85e58629259bb5a385d53e52d162d1463d4ff')
 if [ "${CARCH}" == 'x86_64' ]; then
        # Git for Windows' i686-bit SDK does not have the `autotools` package
-       makedepends+=('perl-devel' 'python-devel' 'ruby' 'autotools')
+       makedepends+=('perl-devel' 'python-devel' 'ruby' 'autotools' 'libxcrypt-devel')
+       depends+=('libxcrypt')
 elif [ "${CARCH}" == 'i686' ]; then
        makedepends+=('libcrypt-devel')
 fi
@@ -93,7 +96,6 @@ check() {
 
 package() {
   cd "${srcdir}"/${pkgname}-${pkgver}
-  make -j1 VIMRCLOC=/etc DESTDIR="${pkgdir}" install
 
   make install -j1 \
     VIMRCLOC=/etc VIMRUNTIMEDIR=/usr/share/vim/vim${_topver/\.} \


### PR DESCRIPTION
To allow Git for Windows to build corresponding i686 package, let's synchronize with the package definition in MSYS2.

This is needed to lose its tight dependency on `msys-perl5_36.dll`.