### PR TITLE
i686: rebuild libfido2 to link to the new libcbor version

### DIFF
--- a/libfido2/PKGBUILD
+++ b/libfido2/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libfido2
 pkgname=("${pkgbase}" "fido2-tools" "${pkgbase}-devel" "${pkgbase}-docs")
 pkgver=1.14.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Library functionality for FIDO 2.0, including communication with a device over USB"
 arch=('i686' 'x86_64')
 url="https://developers.yubico.com/libfido2/"


### PR DESCRIPTION
When the new libcbor version was deployed, we intended to build the libfido2 dependencee just afterwards so that it would pick up the new version, but timing conspired against us and the i686 variant of libfido2 1.40.0-2 [still links to libcbor 0.10.0-1](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/7787616041/job/21235168385#step:10:57).

So let's bump the `pkgrel` once more.