### PR TITLE
Some fixes for curl 8.11.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,26 @@ jobs:
       - name: install pactoys (needed for `saneman`)
         shell: bash
         run: bash -lc "pacman -S --noconfirm pactoys"
+      - name: work around curl v8.11.0-1 problem
+        shell: bash
+        run: |
+          # `git fetch` does not work with that libcurl version. For details,
+          # see https://github.com/git-for-windows/MSYS2-packages/pull/199
+          test ! -f /var/lib/pacman/local/libcurl-8.11.0-1/desc ||
+          for pkg in libcurl curl
+          do
+            for suffix in '' .sig
+            do
+              curl --retry 5 -fLO \
+                https://wingit.blob.core.windows.net/x86-64/$pkg-8.10.1-1-x86_64.pkg.tar.xz$suffix ||
+              exit 1
+            done
+            pacman -U --noconfirm $pkg-8.10.1-1-x86_64.pkg.tar.xz || exit 1
+          done
+
+          # Sadly, this does not work because the Pacman repository's index only
+          # ever lists the latest package version:
+          # pacman -S --noconfirm libcurl=8.10.1-1 curl=8.10.1-1
       - name: CI-Build
         shell: bash
         run: bash -l .ci/ci-build.sh

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -6,8 +6,8 @@ pkgver=8.11.0
 pkgrel=1
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
-url="https://curl.haxx.se"
-license=('MIT')
+url="https://curl.se/"
+license=('spdx:MIT')
 depends=('ca-certificates')
 makedepends=('heimdal-devel' 'libcrypt-devel' 'libidn2-devel'
              'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #  'libcares-devel'

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=8.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.se/"
@@ -13,15 +13,21 @@ makedepends=('heimdal-devel' 'libcrypt-devel' 'libidn2-devel'
              'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #  'libcares-devel'
 options=('!libtool' 'strip' '!debug')
 source=("https://github.com/curl/curl/releases/download/${pkgbase}-${pkgver//./_}/${pkgbase}-${pkgver}.tar.bz2"{,.asc}
-        curl-8.10.0-msys2.patch)
+        curl-8.10.0-msys2.patch
+        "netrc-regression-1.patch::https://github.com/curl/curl/commit/f5c616930b5cf148b1b2632da4f5963ff48bdf88.patch"
+        "netrc-regression-2.patch::https://github.com/curl/curl/commit/0cdde0fdfbeb8c35420f6d03fa4b77ed73497694.patch")
 sha256sums=('c95d5a1368803729345a632ce42cceeefd5f09c3b4d9582f858f6779f4b8b254'
             'SKIP'
-            'f3d1ff0ca77636323ee5156c14275cb6cec98021aa0ad1b30735dbc4c3b619fd')
+            'f3d1ff0ca77636323ee5156c14275cb6cec98021aa0ad1b30735dbc4c3b619fd'
+            '708429a4e0b387dc9addc1f9166e07e5db22da42221887ddab9533c9e2bd1ca8'
+            'd817dd3746476bc513edd24a4f9a32674c3d5a04484bf80d894c1d2add67e8e2')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')   # Daniel Stenberg
 
 prepare() {
   cd "${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/curl-8.10.0-msys2.patch
+  patch -p1 -i ${srcdir}/netrc-regression-1.patch
+  patch -p1 -i ${srcdir}/netrc-regression-2.patch
   autoreconf -fiv
 }
 

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -37,15 +37,13 @@ build() {
     --enable-debug \
     --enable-optimize \
     --enable-ipv6 \
-    --disable-hidden-symbols \
+    --disable-symbol-hiding \
     --disable-ares \
     --with-gssapi \
-    --with-libidn \
+    --with-libidn2 \
     --without-librtmp \
     --with-libssh2 \
-    --without-spnego \
-    --with-ssl \
-    --without-gnutls \
+    --with-openssl \
     --with-zlib \
     --with-libpsl \
     --with-ca-bundle=/usr/ssl/certs/ca-bundle.crt \

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -17,13 +17,12 @@ source=("https://github.com/curl/curl/releases/download/${pkgbase}-${pkgver//./_
 sha256sums=('c95d5a1368803729345a632ce42cceeefd5f09c3b4d9582f858f6779f4b8b254'
             'SKIP'
             'f3d1ff0ca77636323ee5156c14275cb6cec98021aa0ad1b30735dbc4c3b619fd')
-validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'   # Daniel Stenberg
-              '914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg (old key)
+validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')   # Daniel Stenberg
 
 prepare() {
   cd "${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/curl-8.10.0-msys2.patch
-  autoreconf -fi
+  autoreconf -fiv
 }
 
 build() {


### PR DESCRIPTION
The main motivation for this is to fix the PR build problem encountered in https://github.com/git-for-windows/MSYS2-packages/pull/198. [The symptom](https://github.com/git-for-windows/MSYS2-packages/actions/runs/11821394230/job/32936178466?pr=198#step:5:10):

> assertion "s->init == 0xbee51da" failed: file "dynbuf.c", line 242, function: Curl_dyn_ptr

Turns out that this was reported [and diagnosed as a curl bug](https://github.com/curl/curl/issues/15496#issuecomment-2461264595), and fixed via https://github.com/msys2/MSYS2-packages/pull/5005 (thanks @lazka for figuring this all out for me!).

This here PR ports that fix to the `curl` package of Git for Windows. While at it, this also drops a couple of unnecessary deviations from the MSYS2 project's `curl` package definition.