### PR TITLE
Migrate libcrypt -> libxcrypt.

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
 pkgver=8.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
 url="https://curl.se/"
 license=('spdx:MIT')
 depends=('ca-certificates')
-makedepends=('heimdal-devel' 'libcrypt-devel' 'libidn2-devel'
+makedepends=('heimdal-devel' 'libxcrypt-devel' 'libidn2-devel'
              'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #  'libcares-devel'
 options=('!libtool' 'strip' '!debug')
 source=("https://github.com/curl/curl/releases/download/${pkgbase}-${pkgver//./_}/${pkgbase}-${pkgver}.tar.bz2"{,.asc}
@@ -53,7 +53,7 @@ build() {
 }
 
 package_curl() {
-  depends=('ca-certificates' 'libcurl' 'libcrypt'
+  depends=('ca-certificates' 'libcurl' 'libxcrypt'
            'libnghttp2' 'libpsl' 'openssl' 'zlib')
   groups=('base')
 
@@ -67,7 +67,7 @@ package_curl() {
 
 package_libcurl() {
   pkgdesc="Multi-protocol file transfer library (runtime)"
-  depends=('ca-certificates' 'heimdal-libs' 'libcrypt' 'libidn2'
+  depends=('ca-certificates' 'heimdal-libs' 'libxcrypt' 'libidn2'
           'libnghttp2' 'libpsl' 'libssh2' 'openssl' 'zlib') #'libcares'
   groups=('libraries')
 
@@ -77,7 +77,7 @@ package_libcurl() {
 
 package_libcurl-devel() {
   pkgdesc="Libcurl headers and libraries"
-  depends=("libcurl=${pkgver}" 'heimdal-devel' 'libcrypt-devel' 'libidn2-devel'
+  depends=("libcurl=${pkgver}" 'heimdal-devel' 'libxcrypt-devel' 'libidn2-devel'
            'libnghttp2-devel' 'libpsl-devel' 'libssh2-devel' 'openssl-devel' 'zlib-devel') #'libcares-devel'
   options=('staticlibs')
   groups=('development')

--- a/heimdal/PKGBUILD
+++ b/heimdal/PKGBUILD
@@ -3,12 +3,12 @@
 pkgbase=heimdal
 pkgname=('heimdal' 'heimdal-libs' 'heimdal-devel')
 pkgver=7.8.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Implementation of Kerberos V5 libraries"
 arch=('i686' 'x86_64')
 url="https://www.h5l.org/"
 license=('custom')
-makedepends=('libcrypt-devel' 'libedit-devel' 'libsqlite-devel' 'openssl-devel') #libldap-devel
+makedepends=('libxcrypt-devel' 'libedit-devel' 'libsqlite-devel' 'openssl-devel') #libldap-devel
 options=('!libtool' '!emptydirs' 'staticlibs')
 groups=('net-utils')
 source=(https://github.com/heimdal/heimdal/releases/download/heimdal-${pkgver}/heimdal-${pkgver}.tar.gz{,.sig}
@@ -134,7 +134,7 @@ package_heimdal() {
 }
 
 package_heimdal-libs() {
-  depends=('libcrypt' 'libedit' 'libsqlite' 'libopenssl')
+  depends=('libxcrypt' 'libedit' 'libsqlite' 'libopenssl')
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -144,7 +144,7 @@ package_heimdal-libs() {
 package_heimdal-devel() {
   pkgdesc="Heimdal headers and libraries"
   groups=('development')
-  depends=('heimdal-libs' 'libcrypt-devel' 'libedit-devel' 'libsqlite-devel')
+  depends=('heimdal-libs' 'libxcrypt-devel' 'libedit-devel' 'libsqlite-devel')
 
   mkdir -p ${pkgdir}/usr
 

--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=openssh
 pkgver=9.9p1
-pkgrel=1
+pkgrel=2
 pkgdesc='Free version of the SSH connectivity tools'
 url='http://www.openssh.org/portable.html'
 license=('custom:BSD')
 arch=('i686' 'x86_64')
 groups=('net-utils')
-depends=('libfido2' 'heimdal' 'libedit' 'libcrypt' 'openssl')
-makedepends=('libfido2-devel' 'libcbor-devel' 'heimdal-devel' 'libedit-devel' 'libcrypt-devel' 'openssl-devel')
+depends=('libfido2' 'heimdal' 'libedit' 'libxcrypt' 'openssl')
+makedepends=('libfido2-devel' 'libcbor-devel' 'heimdal-devel' 'libedit-devel' 'libxcrypt-devel' 'openssl-devel')
 source=("https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkgname}-${pkgver}.tar.gz"{,.asc}
         0001-Forward-port-MSys2-patches.patch
         0002-openssh-work-around-Cygwin-declaring-setkey.patch

--- a/perl-Clone/PKGBUILD
+++ b/perl-Clone/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=Clone
 pkgname=perl-${_realname}
 pkgver=0.46
-pkgrel=1
+pkgrel=2
 pkgdesc='Recursive copy of nested objects.'
 arch=('i686' 'x86_64')
 url='https://search.cpan.org/~RDF/Clone'
 groups=('perl-modules')
 license=('GPL' 'PerlArtistic')
 depends=('perl')
-makedepends=('libcrypt-devel' 'gcc' 'make')
+makedepends=('libxcrypt-devel' 'gcc' 'make')
 options=('!emptydirs')
 source=("https://search.cpan.org/CPAN/authors/id/G/GA/GARU/${_realname}-${pkgver}.tar.gz")
 sha512sums=('f8bb1010364e94c7cc8bba25681cd9fd737ec2935a8be960ac53099359729fc679190a115dd082fccd239b35762dee2b3be3adbddce37e4ceae6fe934fbad545')

--- a/perl-HTML-Parser/PKGBUILD
+++ b/perl-HTML-Parser/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=HTML-Parser
 pkgname=perl-${_realname}
 pkgver=3.81
-pkgrel=1
+pkgrel=2
 pkgdesc="Perl HTML parser class"
 arch=('i686' 'x86_64')
 license=('PerlArtistic')
 url="http://search.cpan.org/dist/HTML-Parser/"
 groups=('perl-modules')
 depends=('perl-HTML-Tagset' 'perl')
-makedepends=('libcrypt-devel')
+makedepends=('libxcrypt-devel')
 checkdepends=('perl-Test-Pod')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/O/OA/OALDERS/${_realname}-${pkgver}.tar.gz)

--- a/perl-Locale-Gettext/PKGBUILD
+++ b/perl-Locale-Gettext/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=Locale-Gettext
 pkgname=perl-${_realname}
 pkgver=1.07
-pkgrel=7
+pkgrel=8
 groups=('perl-modules')
 pkgdesc="Permits access from Perl to the gettext() family of functions"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
 url="http://search.cpan.org/dist/${_realname}/"
 depends=('gettext' 'perl')
-makedepends=('libcrypt-devel')
+makedepends=('libxcrypt-devel')
 options=(!emptydirs)
 source=(${_realname}-${pkgver}.tar.gz::"https://www.cpan.org/authors/id/P/PV/PVANDRY/Locale-gettext-${pkgver}.tar.gz")
 sha256sums=('909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15')

--- a/perl-Net-SSLeay/PKGBUILD
+++ b/perl-Net-SSLeay/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=Net-SSLeay
 pkgname=perl-${_realname}
 pkgver=1.92
-pkgrel=3
+pkgrel=4
 pkgdesc="Perl extension for using OpenSSL"
 arch=('i686' 'x86_64')
 license=('custom:BSD')
 url="http://search.cpan.org/dist/${_realname}/"
 groups=('perl-modules')
-makedepends=('openssl-devel' 'libcrypt-devel')
+makedepends=('openssl-devel' 'libxcrypt-devel')
 depends=('openssl')
 options=(!emptydirs)
 replaces=('net-ssleay')

--- a/perl-TermReadKey/PKGBUILD
+++ b/perl-TermReadKey/PKGBUILD
@@ -3,12 +3,12 @@
 _realname=TermReadKey
 pkgname=perl-${_realname}
 pkgver=2.38
-pkgrel=8
+pkgrel=9
 pkgdesc="Provides simple control over terminal driver modes"
 arch=('i686' 'x86_64')
 license=('custom')
 depends=('perl')
-makedepends=('libcrypt-devel')
+makedepends=('libxcrypt-devel')
 url="http://search.cpan.org/~jstowe/${_realname}/"
 groups=('perl-modules')
 options=('!emptydirs')

--- a/perl-XML-Parser/PKGBUILD
+++ b/perl-XML-Parser/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=XML-Parser
 pkgname=perl-${_realname}
 pkgver=2.46
-pkgrel=7
+pkgrel=8
 pkgdesc="Expat-based XML parser module for perl"
 arch=('i686' 'x86_64')
 license=('GPL' 'PerlArtistic')
 url="http://search.cpan.org/dist/${_realname}/"
 groups=('perl-modules')
-depends=('perl' 'libexpat' 'libcrypt')
-makedepends=('libexpat-devel' 'libcrypt-devel')
+depends=('perl' 'libexpat' 'libxcrypt')
+makedepends=('libexpat-devel' 'libxcrypt-devel')
 replaces=('perlxml')
 provides=("perlxml=${pkgver}")
 options=('!emptydirs')

--- a/perl-YAML-Syck/PKGBUILD
+++ b/perl-YAML-Syck/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=YAML-Syck
 pkgname=perl-YAML-Syck
 pkgver=1.34
-pkgrel=3
+pkgrel=4
 pkgdesc="Fast, lightweight YAML loader and dumper"
 arch=('i686' 'x86_64')
 url="http://search.cpan.org/dist/YAML-Syck/"
 license=('BSD' 'custom')
 depends=('perl')
-makedepends=('libcrypt-devel')
+makedepends=('libxcrypt-devel')
 groups=('perl-modules')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/T/TO/TODDR/YAML-Syck-${pkgver}.tar.gz

--- a/perl/PKGBUILD
+++ b/perl/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=perl
 pkgver=5.38.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A highly capable, feature-rich programming language"
 arch=(i686 x86_64)
 license=('GPL')
 url="https://www.perl.org/"
 groups=('base-devel')
-depends=('libcrypt' 'coreutils' 'msys2-runtime' 'sh')
-makedepends=('libcrypt-devel')
+depends=('libxcrypt' 'coreutils' 'msys2-runtime' 'sh')
+makedepends=('libxcrypt-devel')
 source=(https://www.cpan.org/src/5.0/perl-${pkgver}.tar.xz
         perlbin.sh
         perlbin.csh


### PR DESCRIPTION
libcrypt-devel was removed in July 2023, and libcrypt was removed in October 2023.

~also drop some crazy i686 workarounds from vim, because i686 has now been synced so they are no longer necessary.~