### PR TITLE
msys2-runtime: strip it

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.6.3
-pkgrel=5
+pkgrel=6
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -306,7 +306,6 @@ build() {
 package_msys2-runtime() {
   pkgdesc="Posix emulation engine for Windows"
   groups=('base')
-  options=('!strip')
   conflicts=('catgets' 'libcatgets' 'msys2-runtime-3.4')
   replaces=('catgets' 'libcatgets' 'msys2-runtime-3.4')
 


### PR DESCRIPTION
Upstream no longer manually strips the cygwin dll and creates a debug file since https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=99bb3e937a0fdbc1e3acbdc7cefb31e54a89a6ac

This means the debug info now moved from msys2-runtime-devel to msys2-runtime staying in the DLL.

We don't really want to install/ship debug infos by default, so we could either re-implement the debug info extraction manually again, or let makepkg build a separate "-debug" package, or just strip everything.

Since the later is the least work and the least special compared to other packages, just enable stripping.

(cherry picked from commit d24e4dabb9cb22af519e46b88eb202efba6387b4)