### PR TITLE
openssh: rebuild for openssl 3.5.3

### DIFF
--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=openssh
 pkgver=10.0p1
-pkgrel=1
+pkgrel=2
 pkgdesc='Free version of the SSH connectivity tools'
 url='http://www.openssh.org/portable.html'
 license=('custom:BSD')


### PR DESCRIPTION
Any invocation of ssh currently fails with the message "OpenSSL version mismatch. Built against 30200040, you have 3050003f".

Fix this by rebuilding OpenSSH against our current OpenSSL.
See also https://github.com/msys2/MSYS2-packages/issues/5650