### PR TITLE
msys2-runtime: avoid stripping to allow code-signing again

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -261,7 +261,7 @@ build() {
   # split debug info from msys-2.0.dll
   cd "${srcdir}"/dest
   objcopy --add-gnu-debuglink=/dev/null --only-keep-debug usr/bin/msys-2.0.dll usr/bin/msys-2.0.dbg
-  objcopy -g --add-gnu-debuglink=usr/bin/msys-2.0.dbg usr/bin/msys-2.0.dll usr/bin/msys-2.0.dll.new
+  objcopy --strip-debug --strip-unneeded --add-gnu-debuglink=usr/bin/msys-2.0.dbg usr/bin/msys-2.0.dll usr/bin/msys-2.0.dll.new
   mv -f usr/bin/msys-2.0.dll.new usr/bin/msys-2.0.dll
 }
 

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=3.6.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
@@ -237,8 +237,10 @@ build() {
     OPTIM="-O2"
   fi
 
-  CFLAGS="$OPTIM -pipe -ggdb"
-  CXXFLAGS="$OPTIM -pipe -ggdb"
+  # We use `-g0` here to suppress debug symbols, to avoid having to call `strip.exe`
+  # on the binary files (which would break code-signing those files).
+  CFLAGS="$OPTIM -pipe -g0"
+  CXXFLAGS="$OPTIM -pipe -g0"
 
   # otherwise it asks git which appends "-dirty" because of our uncommited patches
   CFLAGS+=" -DCYGPORT_RELEASE_INFO=${pkgver}"
@@ -265,6 +267,7 @@ build() {
 
 package_msys2-runtime() {
   pkgdesc="Posix emulation engine for Windows"
+  options=('!strip')
   conflicts=('catgets' 'libcatgets' 'msys2-runtime-3.6')
   replaces=('catgets' 'libcatgets' 'msys2-runtime-3.6')
 

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -9,14 +9,15 @@ pkgdesc="Cygwin POSIX emulation engine"
 arch=('x86_64')
 url="https://www.cygwin.com/"
 license=('GPL')
-groups=('base')
+msys2_references=(
+  'cygwin: cygwin'
+  "cpe: cpe:/a:cygwin:cygwin"
+)
 makedepends=('cocom'
-             'texinfo'
              'git'
              'perl'
              'gcc'
-             'make'
-             'mingw-w64-cross-crt-git'
+             'mingw-w64-cross-crt'
              'mingw-w64-cross-gcc'
              'mingw-w64-cross-zlib'
              'zlib-devel'
@@ -173,9 +174,8 @@ prepare() {
     winsup/cygwin/msys2_path_conv.h \
     winsup/cygwin/include/cygwin/exit_process.h \
     winsup/utils/mingw/getprocaddr.c
-  apply_git_am_with_msg \
- \
-  0001-Fix-msys-library-name-in-import-libraries.patch \
+
+ apply_git_am_with_msg 0001-Fix-msys-library-name-in-import-libraries.patch \
   0002-Rename-dll-from-cygwin-to-msys.patch \
   0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch \
   0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch \
@@ -237,17 +237,11 @@ build() {
     OPTIM="-O2"
   fi
 
-  CFLAGS="$OPTIM -pipe -g0 -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
-  CXXFLAGS="$OPTIM -pipe -g0 -Wno-error=deprecated -Wno-error=stringop-truncation -Wno-error=missing-attributes -Wno-error=maybe-uninitialized" #-Wno-error=class-memaccess
+  CFLAGS="$OPTIM -pipe -ggdb"
+  CXXFLAGS="$OPTIM -pipe -ggdb"
 
   # otherwise it asks git which appends "-dirty" because of our uncommited patches
   CFLAGS+=" -DCYGPORT_RELEASE_INFO=${pkgver}"
-
-  # XXX: cygwin still uses gcc v11 so we get new warnings with v13,
-  # resulting in errors. We can't selectively disable warnigns since our
-  # cross compiler is also too old and doesn't understand the new
-  # warning flags, so we need to disable all errors for now.
-  export CXXFLAGS="-Wno-error -Wno-narrowing"
 
   (cd "${srcdir}/msys2-runtime/winsup" && ./autogen.sh)
 
@@ -258,33 +252,26 @@ build() {
     --sysconfdir=/etc \
     "${extra_config[@]}"
   LC_ALL=C make
-
-  if test -n "$SIGNTOOL"
-  then
-    eval "$SIGNTOOL" \
-      ${PWD}/${CHOST}/winsup/cygwin/new-msys-2.0.dll \
-      ${PWD}/${CHOST}/winsup/utils/*.exe ${PWD}/${CHOST}/winsup/utils/mingw/*.exe
-  fi
-
   LC_ALL=C make -j1 DESTDIR="${srcdir}"/dest install
 
-  #pushd ${CHOST}/winsup/cygwin > /dev/null
-  #LANG=C make libmsys2_s.a
-  #cp libmsys2_s.a "${srcdir}"/dest/usr/${CHOST}/lib/
-  #popd > /dev/null
-
   rm -rf "${srcdir}"/dest/etc
+
+  # split debug info from msys-2.0.dll
+  cd "${srcdir}"/dest
+  objcopy --add-gnu-debuglink=/dev/null --only-keep-debug usr/bin/msys-2.0.dll usr/bin/msys-2.0.dbg
+  objcopy -g --add-gnu-debuglink=usr/bin/msys-2.0.dbg usr/bin/msys-2.0.dll usr/bin/msys-2.0.dll.new
+  mv -f usr/bin/msys-2.0.dll.new usr/bin/msys-2.0.dll
 }
 
 package_msys2-runtime() {
   pkgdesc="Posix emulation engine for Windows"
-  groups=('base')
-  conflicts=('catgets' 'libcatgets' 'msys2-runtime-3.4')
-  replaces=('catgets' 'libcatgets' 'msys2-runtime-3.4')
+  conflicts=('catgets' 'libcatgets' 'msys2-runtime-3.6')
+  replaces=('catgets' 'libcatgets' 'msys2-runtime-3.6')
 
   mkdir -p "${pkgdir}"/usr
   cp -rf "${srcdir}"/dest/usr/bin "${pkgdir}"/usr/
   cp -rf "${srcdir}"/dest/usr/libexec "${pkgdir}"/usr/
+  rm -f "${pkgdir}"/usr/bin/msys-2.0.dbg
   rm -f "${pkgdir}"/usr/bin/cyglsa-config
   rm -f "${pkgdir}"/usr/bin/cyglsa.dll
   rm -f "${pkgdir}"/usr/bin/cyglsa64.dll
@@ -294,12 +281,14 @@ package_msys2-runtime() {
 
 package_msys2-runtime-devel() {
   pkgdesc="MSYS2 headers and libraries"
-  groups=('msys2-devel')
   depends=("msys2-runtime=${pkgver}")
-  conflicts=('libcatgets-devel' 'msys2-runtime-3.4-devel')
-  replaces=('libcatgets-devel' 'msys2-runtime-3.4-devel')
+  conflicts=('libcatgets-devel' 'msys2-runtime-3.6-devel')
+  replaces=('libcatgets-devel' 'msys2-runtime-3.6-devel')
+  # strip breaks the split debug info.  msys2/msys2-pacman#52
+  options=('!strip')
 
   mkdir -p "${pkgdir}"/usr/bin
+  cp -f "${srcdir}"/dest/usr/bin/msys-2.0.dbg "${pkgdir}"/usr/bin/
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/include "${pkgdir}"/usr/
   rm -f "${pkgdir}"/usr/include/iconv.h
   rm -f "${pkgdir}"/usr/include/unctrl.h
@@ -307,25 +296,7 @@ package_msys2-runtime-devel() {
   rm -fr "${pkgdir}"/usr/include/rpc/
 
   cp -rLf "${srcdir}"/dest/usr/${CHOST}/lib "${pkgdir}"/usr/
+
+  # compatibility with Cygwin toolchains
+  cp "${srcdir}"/dest/usr/${CHOST}/lib/libmsys-2.0.a "${pkgdir}"/usr/lib/libcygwin.a
 }
-
-# return 0
-# To hack on this:
-# cd /c/repo-MSYS2/msys2-runtime/
-# pushd src/build-i686-pc-msys
-# LANG=C make && make -j1 DESTDIR=/c/repo-MSYS2/msys2-runtime/src/dest install
-# popd
-# makepkg -sRLf
-# pacman -U msys2-runtime*.xz
-
-# Quicker:
-# open cmd.exe
-# set "PATH=C:\\msys32\\usr\\bin;%PATH%"
-# E:
-# pushd E:\m2\repo-MSYS2\msys2-runtime\src\build-i686-pc-msys\i686-pc-msys\winsup\cygwin
-# C:/msys32/usr/bin/bash -c "LANG=C && make"
-# copy /y new-msys-2.0.dll C:\msys32\usr\bin\msys-2.0.dll
-# popd
-# C:
-# C:/msys32/usr/bin/strace ls / > C:/strace.txt 2>&1
-#


### PR DESCRIPTION
Third parties commonly code-sign the MSYS2 runtime when ingesting MinGit, as a way to attest the integrity (_not_ to testify that they have vetted all the supply chain!).

This is currently broken, failing with:

  SignTool Error: SignedCode::Sign returned error: 0x800700C1

    %1 is not a valid Win32 application.

  SignTool Error: An error occurred while attempting to sign: msys-2.0.dll

The reason is that the MSYS toolchain's version of `strip.exe` somehow changes the structure of the output files that are incompatible with `signtool.exe`, as had been identified in ffd1140c74 (bash: avoid stripping after code-signing, 2022-05-02).

Therefore, as of 667799c692 (msys2-runtime: strip it, 2022-12-19), the `msys-2.0.dll` file (and all of the Cygwin utilities like `cygwin-console-helper.exe`) can no longer be signed.

So let's revert that change.

However, we _must_ be _very_ careful not to regress on the cause for that commit: It was triggered by Cygwin's build process all of a sudden including all the debug information in the `msys-2.0.dll` file, which makes it roughly 10x larger (and it already weighs ~3MB to begin with).

The saving grace is the `-g0` part of the `CFLAGS`/`CXXFLAGS` that are hard-coded in the `PKGBUILD` file. This prevents debug information from being generated in th first place.

This fixes https://github.com/git-for-windows/git/issues/5852