### PR TITLE
msys2-runtime: exclude AGENTS.md in update-patches.sh

### DIFF
--- a/msys2-runtime/update-patches.sh
+++ b/msys2-runtime/update-patches.sh
@@ -43,7 +43,7 @@ git -c core.abbrev=7 \
 		--subject-prefix=PATCH \
 		--output-directory ../.. \
 		$base_tag.. ${merging_rebase_start:+^$merging_rebase_start} \
-		-- ':(exclude).github/' ':(exclude)ui-tests/' ||
+		-- ':(exclude).github/' ':(exclude)AGENTS.md' ':(exclude)ui-tests/' ||
 die "Could not generate new patch set"
 
 patches="$(ls 0*.patch)" &&


### PR DESCRIPTION
The msys2-runtime repository recently gained an AGENTS.md file that provides project context for AI coding agents. This file is only useful during development in the msys2-runtime repository itself and is not needed to build the package, so exclude it from the patch series just like .github/ and ui-tests/.