### PR TITLE
bash: speed up the Git test suite on Windows via spawnve() and a built-in expr

### DIFF
--- a/.github/workflows/bash-with-git-tests.yml
+++ b/.github/workflows/bash-with-git-tests.yml
@@ -1,0 +1,181 @@
+name: bash with Git tests
+
+# Build the `bash` package from this branch and run Git's full test
+# suite against a minimal Git for Windows SDK that has had the freshly
+# built bash installed on top of it.  The test step uses git-sdk-64's
+# `test-ci-artifacts.yml` reusable workflow which fans out across 17
+# parallel matrix shards.
+
+on:
+  push:
+    paths:
+      - 'bash/**'
+      - '.github/workflows/bash-with-git-tests.yml'
+  pull_request:
+    paths:
+      - 'bash/**'
+      - '.github/workflows/bash-with-git-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-bash:
+    runs-on: windows-latest
+    outputs:
+      bash-pkg-name: ${{ steps.makepkg.outputs.pkg-name }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Git for Windows SDK
+        uses: git-for-windows/setup-git-for-windows-sdk@v2
+        with:
+          flavor: full
+
+      - name: Build the bash package
+        id: makepkg
+        shell: bash
+        env:
+          # The setup-git-for-windows-sdk action defaults to
+          # MSYSTEM=MINGW64, which makes "shell: bash" run in MinGW
+          # mode.  Building the MSYS bash package itself requires the
+          # MSYS environment so that the msys2-runtime headers (which
+          # define POSIX types like sigset_t and the two-argument
+          # mkdir(2) the bash source expects) are picked up;
+          # otherwise the build fails with "unknown type name
+          # 'sigset_t'" and "too many arguments to function 'mkdir'".
+          MSYSTEM: MSYS
+          CHERE_INVOKING: '1'
+        run: |
+          set -ex
+          cd bash
+          # The "full" SDK does not ship -devel headers for every
+          # makedepends entry; let makepkg pull what is missing via
+          # `--syncdeps` rather than hard-coding a pacman -S list that
+          # would have to track PKGBUILD changes.  Skip the PGP check
+          # since the runner has no keyring loaded for Chet Ramey's
+          # signing key.
+          MAKEFLAGS=-j$(nproc) makepkg --noconfirm \
+              --noprogressbar --syncdeps --skippgpcheck
+          pkg=$(ls bash-*.pkg.tar.* | head -n1)
+          test -n "$pkg"
+          echo "pkg-name=$pkg" >>"$GITHUB_OUTPUT"
+
+      - name: Upload the bash package
+        uses: actions/upload-artifact@v6
+        with:
+          name: bash-pkg
+          path: bash/bash-*.pkg.tar.*
+          if-no-files-found: error
+
+  minimal-sdk-artifact:
+    needs: build-bash
+    runs-on: windows-latest
+    outputs:
+      git-artifacts-extract-location: ${{ steps.git-artifacts-extract-location.outputs.result }}
+    env:
+      G4W_SDK_REPO: git-for-windows/git-sdk-64
+    steps:
+      - name: Get the latest successful ci-artifacts run id
+        id: ci-artifacts-run-id
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const [ owner, repo ] = process.env.G4W_SDK_REPO.split('/')
+            const info = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 938271, // ci-artifacts.yml
+              status: 'success',
+              per_page: 1
+            })
+            return info.data.workflow_runs[0].id
+
+      - name: Download the minimal SDK and git-artifacts tarballs
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -ex
+          run_id=${{ steps.ci-artifacts-run-id.outputs.result }}
+          curl -H "Authorization: token $GITHUB_TOKEN" \
+            -L https://api.github.com/repos/$G4W_SDK_REPO/actions/runs/$run_id/artifacts |
+            jq -r '.artifacts[] | [.name, .archive_download_url] | @tsv' |
+            tr -d '\r' |
+            while read name url
+            do
+              case "$name" in
+              minimal-sdk|git-artifacts)
+                echo "Downloading $name"
+                curl -H "Authorization: token $GITHUB_TOKEN" \
+                  -#sLo /tmp/"$name".zip "$url"
+                unzip -qo /tmp/"$name".zip
+                ;;
+              esac
+            done
+          ls -la git-sdk-x86_64-minimal.tar.gz git-artifacts.tar.gz
+
+      - name: Download the freshly built bash package
+        uses: actions/download-artifact@v7
+        with:
+          name: bash-pkg
+          path: bash-pkg
+
+      - name: Install the freshly built bash into the minimal SDK
+        shell: bash
+        run: |
+          set -ex
+          mkdir minimal-sdk
+          tar -C minimal-sdk -xzf git-sdk-x86_64-minimal.tar.gz
+          # Verify the SDK as-shipped works before we touch it.
+          minimal-sdk/usr/bin/bash.exe --version
+
+          # Extract the .pkg.tar.zst directly into the SDK tree, skipping
+          # the pacman bookkeeping files at the package root.  We do not
+          # have a pacman database inside this stand-alone tree so a
+          # `pacman -U` would refuse to operate; tar extraction is what
+          # `tar -cf - . | tar xf -` against an installed SDK would do
+          # anyway, just without pacman's transactional accounting.
+          pkg=$(ls bash-pkg/bash-*.pkg.tar.* | head -n1)
+          test -n "$pkg"
+          tar -C minimal-sdk --warning=no-unknown-keyword -xf "$pkg" \
+              --exclude=.PKGINFO --exclude=.BUILDINFO \
+              --exclude=.MTREE --exclude=.INSTALL --exclude=.CHANGELOG
+
+          # Confirm our build (not the SDK's stock bash) is in place.
+          minimal-sdk/usr/bin/bash.exe --version
+
+          # Repackage so test-ci-artifacts.yml can consume it unchanged.
+          tar -C minimal-sdk -cf - . |
+            gzip -1 >git-sdk-x86_64-minimal.tar.gz
+
+      - name: Upload the customized minimal SDK
+        uses: actions/upload-artifact@v6
+        with:
+          name: minimal-sdk
+          path: git-sdk-x86_64-minimal.tar.gz
+          if-no-files-found: error
+
+      - name: Determine where git-artifacts wants to be extracted
+        id: git-artifacts-extract-location
+        shell: bash
+        run: |
+          echo "result=$(tar Oxf git-artifacts.tar.gz git/bin-wrappers/git |
+            sed -n 's|^GIT_EXEC_PATH='\''\(.*\)/git'\''$|\1|p')" >>"$GITHUB_OUTPUT"
+
+      - name: Upload git-artifacts for the test job
+        uses: actions/upload-artifact@v6
+        with:
+          name: git-artifacts
+          path: git-artifacts.tar.gz
+          if-no-files-found: error
+
+  test-minimal-sdk:
+    needs: [minimal-sdk-artifact]
+    uses: git-for-windows/git-sdk-64/.github/workflows/test-ci-artifacts.yml@main
+    with:
+      git-artifacts-extract-location: ${{ needs.minimal-sdk-artifact.outputs.git-artifacts-extract-location }}

--- a/bash/0008-builtins-implement-expr.patch
+++ b/bash/0008-builtins-implement-expr.patch
@@ -1,0 +1,785 @@
+From b9cb8b515755c5f5457cc7dd8b17f8c59c12c91b Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 02:51:55 +0200
+Subject: [PATCH 08/N] builtins: implement expr
+
+Like many other POSIX utilities, Git's tests use `expr`
+(https://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html)
+extensively. For example, `test-lib-functions.sh`
+(https://github.com/git/git/blob/master/t/test-lib-functions.sh) runs
+`expr(...)` once per `test_have_prereq(...)` invocation (i.e. roughly
+once per `test_expect_*`) just to validate that the prereq string
+contains only the allowed alphabet, and uses `expr STR : REGEX` for
+various parsing tasks throughout. Each invocation is an external
+`fork(...)` + `exec(...)` of `/usr/bin/expr.exe`, which the MSYS2
+runtime must emulate at a cost of around 14ms even with the upcoming
+`spawnve(...)` fast path (and around double that without that fast
+path). Making `expr` a builtin eliminates the spawn entirely, dropping
+each call to microseconds.
+
+The implementation is a from-scratch recursive-descent evaluator over
+the `argv` variable of type `WORD_LIST` (each operator and operand is
+its own argument, per POSIX). The grammar has seven precedence levels:
+
+  | & {<,<=,=,==,!=,>=,>} {+,-} {*,/,%} : (...)
+
+plus the four named operations `length`, `substr`, `index` and `match`.
+Comparison is numeric when both operands parse as integers and lexical
+otherwise, matching POSIX and the GNU expr behavior that Git relies on
+(e.g. `expr 2.34 \<= "$_GLIBC_VERSION"` falls back to string compare).
+The `:` operator is a BRE match anchored at the start of the left
+operand; if the pattern contains a `\(...\)` capture group, the matched
+substring is returned, otherwise the length of the matched prefix.
+
+Errors are signalled via a `setjmp(...)` / `longjmp(...)` out of the
+recursive descent so that deep parses do not have to thread error
+returns through every level. The exit status follows GNU expr (which
+POSIX permits) conventions: 0 if the result is non-zero/non-empty, 1
+if zero/empty, and 2 for any error (syntax error, division by zero,
+regex compile failure).
+
+A note on disambiguation: per POSIX, `length`, `substr`, `index` and
+`match` are keywords only by position, not absolutely; a user's
+`expr length` where `length` is itself the value being measured is
+supposed to be disambiguated with the GNU `+` quoter. This builtin
+takes the keyword interpretation whenever the remaining `argv` has
+the right shape; that is good enough for every use of `expr` in Git's
+test suite and matches what GNU expr does in practice for the unquoted
+case.
+
+The `.def` boilerplate follows the `let.def` template closely: a plain
+`WORD_LIST` to `int` builtin with `CHECK_HELPOPT` and the standard
+`--` leading-separator skip. `builtins/Makefile.in` gets the new
+`.def` added to `DEFSRC`, `expr.o` added to `OFILES`, and a header-dep
+stanza copied from `let.o`.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ builtins/Makefile.in |  15 +-
+ builtins/expr.def    | 659 +++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 672 insertions(+), 2 deletions(-)
+ create mode 100644 builtins/expr.def
+
+diff --git a/builtins/Makefile.in b/builtins/Makefile.in
+index 7e0ec32..9e28d36 100644
+--- a/builtins/Makefile.in
++++ b/builtins/Makefile.in
+@@ -152,7 +152,8 @@ DEFSRC =  $(srcdir)/alias.def $(srcdir)/bind.def $(srcdir)/break.def \
+ 	  $(srcdir)/times.def $(srcdir)/trap.def $(srcdir)/type.def \
+ 	  $(srcdir)/ulimit.def $(srcdir)/umask.def $(srcdir)/wait.def \
+ 	  $(srcdir)/reserved.def $(srcdir)/pushd.def $(srcdir)/shopt.def \
+-	  $(srcdir)/printf.def $(srcdir)/complete.def $(srcdir)/mapfile.def
++	  $(srcdir)/printf.def $(srcdir)/complete.def $(srcdir)/mapfile.def \
++	  $(srcdir)/expr.def
+ 
+ STATIC_SOURCE = common.c evalstring.c evalfile.c getopt.c bashgetopt.c \
+ 		getopt.h 
+@@ -164,7 +165,8 @@ OFILES = builtins.o \
+ 	jobs.o kill.o let.o mapfile.o \
+ 	pushd.o read.o return.o set.o setattr.o shift.o source.o \
+ 	suspend.o test.o times.o trap.o type.o ulimit.o umask.o \
+-	wait.o getopts.o shopt.o printf.o getopt.o bashgetopt.o complete.o
++	wait.o getopts.o shopt.o printf.o getopt.o bashgetopt.o complete.o \
++	expr.o
+ 
+ CREATED_FILES = builtext.h builtins.c psize.aux pipesize.h tmpbuiltins.c \
+ 	tmpbuiltins.h
+@@ -333,6 +335,7 @@ wait.o: wait.def
+ getopts.o: getopts.def
+ reserved.o: reserved.def
+ complete.o: complete.def
++expr.o: expr.def
+ 
+ # C files
+ bashgetopt.o: ../config.h $(topdir)/bashansi.h $(BASHINCDIR)/ansi_stdlib.h
+@@ -557,6 +560,13 @@ let.o: $(topdir)/subst.h $(topdir)/externs.h $(BASHINCDIR)/maxpath.h
+ let.o: $(topdir)/shell.h $(topdir)/syntax.h $(topdir)/unwind_prot.h $(topdir)/variables.h $(topdir)/conftypes.h
+ let.o: ../pathnames.h
+ let.o: $(BASHINCDIR)/unlocked-io.h
++expr.o: $(topdir)/command.h ../config.h $(BASHINCDIR)/memalloc.h
++expr.o: $(topdir)/error.h $(topdir)/general.h $(topdir)/xmalloc.h
++expr.o: $(topdir)/quit.h $(topdir)/dispose_cmd.h $(topdir)/make_cmd.h $(topdir)/sig.h
++expr.o: $(topdir)/subst.h $(topdir)/externs.h $(BASHINCDIR)/maxpath.h
++expr.o: $(topdir)/shell.h $(topdir)/syntax.h $(topdir)/unwind_prot.h $(topdir)/variables.h $(topdir)/conftypes.h
++expr.o: ../pathnames.h
++expr.o: $(BASHINCDIR)/unlocked-io.h
+ printf.o: ../config.h $(BASHINCDIR)/memalloc.h $(topdir)/bashjmp.h
+ printf.o: $(topdir)/command.h $(topdir)/error.h $(topdir)/general.h $(topdir)/xmalloc.h
+ printf.o: $(topdir)/quit.h $(topdir)/dispose_cmd.h $(topdir)/make_cmd.h
+@@ -746,6 +756,7 @@ inlib.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ jobs.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ kill.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ let.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
++expr.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ mapfile.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ mkbuiltins.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+ printf.o: ${topdir}/bashintl.h ${LIBINTL_H} $(BASHINCDIR)/gettext.h
+diff --git a/builtins/expr.def b/builtins/expr.def
+new file mode 100644
+index 0000000..b245bf9
+--- /dev/null
++++ b/builtins/expr.def
+@@ -0,0 +1,659 @@
++This file is expr.def, from which is created expr.c.
++It implements the builtin "expr" in Bash.
++
++Copyright (C) 2026 Free Software Foundation, Inc.
++
++This file is part of GNU Bash, the Bourne Again SHell.
++
++Bash is free software: you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation, either version 3 of the License, or
++(at your option) any later version.
++
++Bash is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with Bash. If not, see <http://www.gnu.org/licenses/>.
++
++$PRODUCES expr.c
++
++$BUILTIN expr
++$FUNCTION expr_builtin
++$SHORT_DOC expr EXPRESSION
++Evaluate an expression and write the result to standard output.
++
++EXPRESSION is composed of operators (in order of increasing precedence):
++
++	EXPR1 | EXPR2	EXPR1 if non-null and non-zero, else EXPR2
++	EXPR1 & EXPR2	EXPR1 if both non-null and non-zero, else 0
++	EXPR1 RELOP EXPR2  comparison: <, <=, =, !=, >=, >
++			(numeric if both operands are integers, else
++			 lexical)
++	EXPR1 +/- EXPR2	arithmetic
++	EXPR1 *,/,% EXPR2	arithmetic
++	STR : REGEX	BRE match, anchored at start of STR; result is
++			the first \( \) group, or the length of the
++			match if there is no group
++	( EXPR )	grouping
++
++	length STR	character length of STR
++	substr STR POS LEN	substring of STR starting at POS (1-based),
++			at most LEN characters
++	index STR CHARS	first 1-based position in STR of any character
++			in CHARS, or 0
++	match STR REGEX	same as STR : REGEX
++
++Each operator and operand must be a separate argument.
++
++Exit Status:
++0 if EXPR is non-null and non-zero, 1 if EXPR is null or zero, 2 on
++invalid expression, 3 on internal error.
++$END
++
++#include <config.h>
++
++#if defined (HAVE_UNISTD_H)
++#  include <unistd.h>
++#endif
++
++#include <stdio.h>
++#include <ctype.h>
++#include <errno.h>
++#include <setjmp.h>
++#include <regex.h>
++
++#if defined (HAVE_INTTYPES_H)
++#  include <inttypes.h>
++#endif
++
++#include "../bashansi.h"
++#include "../bashintl.h"
++
++#include "../shell.h"
++#include "common.h"
++#include "bashgetopt.h"
++
++#define EXPR_INVALID	2
++#define EXPR_ERROR	3
++
++/* A value is either a string, a number, or both (when a string also
++   parses as a valid integer). STR is always non-NULL and freshly
++   allocated; the caller takes ownership when consuming a value. */
++struct val
++{
++  char *str;
++  intmax_t num;
++  int have_num;
++};
++
++/* Parser state. TOK points at the next argv slot to consume; END is
++   one past the last. ERR_JMP is used to bail out of arbitrarily
++   deep recursion on a syntax error. */
++struct parser
++{
++  WORD_LIST *tok;
++  jmp_buf err_jmp;
++  int err_status;
++};
++
++static struct val *parse_or (struct parser *, int);
++
++/* True if S is a valid (possibly signed) decimal integer with no
++   trailing garbage. */
++static int
++expr_is_integer (const char *s, intmax_t *np)
++{
++  const char *p = s;
++  if (*p == '-')
++    p++;
++  if (!*p)
++    return 0;
++  while (isdigit ((unsigned char)*p))
++    p++;
++  if (*p)
++    return 0;
++  return legal_number (s, np);
++}
++
++static struct val *
++val_str (char *s)
++{
++  struct val *v = (struct val *)xmalloc (sizeof *v);
++  v->str = s;
++  v->have_num = expr_is_integer (s, &v->num);
++  return v;
++}
++
++static struct val *
++val_num (intmax_t n)
++{
++  struct val *v = (struct val *)xmalloc (sizeof *v);
++  v->str = itos (n);
++  v->num = n;
++  v->have_num = 1;
++  return v;
++}
++
++static struct val *
++val_dup_str (const char *s)
++{
++  return val_str (savestring (s));
++}
++
++static void
++val_free (struct val *v)
++{
++  if (!v)
++    return;
++  free (v->str);
++  free (v);
++}
++
++static int
++val_truthy (struct val *v)
++{
++  if (v->have_num)
++    return v->num != 0;
++  return v->str[0] != '\0';
++}
++
++static intmax_t
++val_to_num (struct parser *p, struct val *v)
++{
++  if (!v->have_num)
++    {
++      builtin_error (_("non-integer argument: %s"), v->str);
++      p->err_status = EXPR_INVALID;
++      longjmp (p->err_jmp, 1);
++    }
++  return v->num;
++}
++
++/* Token classification. POSIX makes argv positions, not contents,
++   the disambiguator: any TOKEN may also be a string operand. We
++   recognize an operator only at positions where the grammar expects
++   one (i.e. as the second argv after a primary). */
++
++static const char *
++peek (struct parser *p)
++{
++  return p->tok ? p->tok->word->word : NULL;
++}
++
++static char *
++consume (struct parser *p)
++{
++  char *s;
++  if (!p->tok)
++    {
++      builtin_error (_("syntax error: unexpected end of expression"));
++      p->err_status = EXPR_INVALID;
++      longjmp (p->err_jmp, 1);
++    }
++  s = p->tok->word->word;
++  p->tok = p->tok->next;
++  return s;
++}
++
++static int
++match_op (struct parser *p, const char *op)
++{
++  const char *t = peek (p);
++  if (t && strcmp (t, op) == 0)
++    {
++      consume (p);
++      return 1;
++    }
++  return 0;
++}
++
++/* The `:` operator and `match`. Anchor PATTERN at start of STR; if
++   PATTERN contains a \( \) group, return the matched substring;
++   otherwise return the length of the matched prefix as a number.
++   No match returns "" (no group) or 0 (group). */
++static struct val *
++expr_match (struct parser *p, struct val *l, struct val *r)
++{
++  regex_t re;
++  regmatch_t pm[2];
++  int rc;
++  struct val *out;
++  /* POSIX BRE, anchored: prefix the pattern with ^ if it is not
++     already anchored, since `:` is left-anchored by definition. */
++  char *anchored;
++  size_t plen = strlen (r->str);
++  int has_group;
++
++  anchored = (char *)xmalloc (plen + 2);
++  if (r->str[0] == '^')
++    memcpy (anchored, r->str, plen + 1);
++  else
++    {
++      anchored[0] = '^';
++      memcpy (anchored + 1, r->str, plen + 1);
++    }
++
++  rc = regcomp (&re, anchored, 0 /* BRE */);
++  if (rc != 0)
++    {
++      char errbuf[256];
++      regerror (rc, &re, errbuf, sizeof errbuf);
++      regfree (&re);
++      free (anchored);
++      builtin_error (_("invalid regular expression: %s"), errbuf);
++      p->err_status = EXPR_INVALID;
++      longjmp (p->err_jmp, 1);
++    }
++  free (anchored);
++
++  has_group = re.re_nsub >= 1;
++  rc = regexec (&re, l->str, has_group ? 2 : 1, pm, 0);
++
++  if (rc != 0 || pm[0].rm_so != 0)
++    {
++      regfree (&re);
++      return has_group ? val_dup_str ("") : val_num (0);
++    }
++
++  if (has_group && pm[1].rm_so >= 0)
++    {
++      size_t glen = pm[1].rm_eo - pm[1].rm_so;
++      char *g = (char *)xmalloc (glen + 1);
++      memcpy (g, l->str + pm[1].rm_so, glen);
++      g[glen] = '\0';
++      regfree (&re);
++      out = val_str (g);
++    }
++  else if (has_group)
++    {
++      regfree (&re);
++      out = val_dup_str ("");
++    }
++  else
++    {
++      out = val_num (pm[0].rm_eo);
++      regfree (&re);
++    }
++  return out;
++}
++
++/* primary ::= '(' or ')' | named_op | TOKEN */
++static struct val *
++parse_primary (struct parser *p, int evaluate)
++{
++  const char *t = peek (p);
++  struct val *v, *a, *b, *c;
++
++  if (!t)
++    {
++      builtin_error (_("syntax error: unexpected end of expression"));
++      p->err_status = EXPR_INVALID;
++      longjmp (p->err_jmp, 1);
++    }
++
++  if (strcmp (t, "(") == 0)
++    {
++      consume (p);
++      v = parse_or (p, evaluate);
++      if (!match_op (p, ")"))
++	{
++	  val_free (v);
++	  builtin_error (_("syntax error: missing `)`"));
++	  p->err_status = EXPR_INVALID;
++	  longjmp (p->err_jmp, 1);
++	}
++      return v;
++    }
++
++  /* Named operations. Per POSIX they only act as keywords if the
++     remaining argv has the right shape; otherwise we treat them as
++     plain string operands. We approximate by always taking them as
++     keywords when the following tokens exist and are not closing
++     delimiters. */
++  if (strcmp (t, "length") == 0 && p->tok->next != NULL)
++    {
++      consume (p);
++      a = parse_primary (p, evaluate);
++      if (evaluate)
++	v = val_num ((intmax_t)strlen (a->str));
++      else
++	v = val_num (0);
++      val_free (a);
++      return v;
++    }
++  /* Bare `length` with no argument is a syntax error. */
++  if (strcmp (t, "length") == 0)
++    {
++      consume (p);
++      builtin_error (_("syntax error: missing argument after `%s'"), "length");
++      p->err_status = EXPR_INVALID;
++      longjmp (p->err_jmp, 1);
++    }
++  if (strcmp (t, "match") == 0
++      && p->tok->next && p->tok->next->next)
++    {
++      consume (p);
++      a = parse_primary (p, evaluate);
++      b = parse_primary (p, evaluate);
++      if (evaluate)
++	v = expr_match (p, a, b);
++      else
++	v = val_num (0);
++      val_free (a);
++      val_free (b);
++      return v;
++    }
++  if (strcmp (t, "index") == 0
++      && p->tok->next && p->tok->next->next)
++    {
++      const char *pos;
++      intmax_t idx = 0;
++      consume (p);
++      a = parse_primary (p, evaluate);
++      b = parse_primary (p, evaluate);
++      if (evaluate)
++	{
++	  pos = strpbrk (a->str, b->str);
++	  if (pos)
++	    idx = (intmax_t)(pos - a->str) + 1;
++	}
++      val_free (a);
++      val_free (b);
++      return val_num (idx);
++    }
++  if (strcmp (t, "substr") == 0
++      && p->tok->next && p->tok->next->next && p->tok->next->next->next)
++    {
++      intmax_t pos, len;
++      size_t slen;
++      char *out;
++      consume (p);
++      a = parse_primary (p, evaluate);
++      b = parse_primary (p, evaluate);
++      c = parse_primary (p, evaluate);
++      if (!evaluate)
++	{
++	  val_free (a);
++	  val_free (b);
++	  val_free (c);
++	  return val_dup_str ("");
++	}
++      pos = val_to_num (p, b);
++      len = val_to_num (p, c);
++      slen = strlen (a->str);
++      if (pos < 1 || (uintmax_t)pos > slen || len < 1)
++	{
++	  val_free (a);
++	  val_free (b);
++	  val_free (c);
++	  return val_dup_str ("");
++	}
++      if ((uintmax_t)(pos - 1 + len) > slen)
++	len = (intmax_t)slen - (pos - 1);
++      out = (char *)xmalloc ((size_t)len + 1);
++      memcpy (out, a->str + pos - 1, (size_t)len);
++      out[len] = '\0';
++      val_free (a);
++      val_free (b);
++      val_free (c);
++      return val_str (out);
++    }
++
++  /* GNU coreutils extension: a leading `+` quotes the next token so
++     that operator-looking strings can be passed as operands.  A bare
++     `+` with nothing following is a syntax error. */
++  if (strcmp (t, "+") == 0 && p->tok->next != NULL)
++    {
++      consume (p);
++      return val_dup_str (consume (p));
++    }
++  if (strcmp (t, "+") == 0)
++    {
++      consume (p);
++      builtin_error (_("syntax error: missing argument after `+'"));
++      p->err_status = EXPR_INVALID;
++      longjmp (p->err_jmp, 1);
++    }
++
++  return val_dup_str (consume (p));
++}
++
++static struct val *
++parse_match (struct parser *p, int evaluate)
++{
++  struct val *l = parse_primary (p, evaluate);
++  while (match_op (p, ":"))
++    {
++      struct val *r = parse_primary (p, evaluate);
++      if (evaluate)
++	{
++	  struct val *n = expr_match (p, l, r);
++	  val_free (l);
++	  l = n;
++	}
++      val_free (r);
++    }
++  return l;
++}
++
++static struct val *
++parse_muldiv (struct parser *p, int evaluate)
++{
++  struct val *l = parse_match (p, evaluate);
++  for (;;)
++    {
++      const char *t = peek (p);
++      intmax_t a, b, r;
++      struct val *rhs;
++      if (!t || (strcmp (t, "*") && strcmp (t, "/") && strcmp (t, "%")))
++	break;
++      consume (p);
++      rhs = parse_match (p, evaluate);
++      if (!evaluate)
++	{
++	  val_free (l);
++	  val_free (rhs);
++	  l = val_num (0);
++	  continue;
++	}
++      a = val_to_num (p, l);
++      b = val_to_num (p, rhs);
++      if (t[0] != '*' && b == 0)
++	{
++	  val_free (l);
++	  val_free (rhs);
++	  builtin_error (_("division by zero"));
++	  p->err_status = EXPR_INVALID;
++	  longjmp (p->err_jmp, 1);
++	}
++      switch (t[0])
++	{
++	case '*': r = a * b; break;
++	case '/': r = a / b; break;
++	default:  r = a % b; break;
++	}
++      val_free (l);
++      val_free (rhs);
++      l = val_num (r);
++    }
++  return l;
++}
++
++static struct val *
++parse_addsub (struct parser *p, int evaluate)
++{
++  struct val *l = parse_muldiv (p, evaluate);
++  for (;;)
++    {
++      const char *t = peek (p);
++      intmax_t a, b, r;
++      struct val *rhs;
++      if (!t || (strcmp (t, "+") && strcmp (t, "-")))
++	break;
++      consume (p);
++      rhs = parse_muldiv (p, evaluate);
++      if (!evaluate)
++	{
++	  val_free (l);
++	  val_free (rhs);
++	  l = val_num (0);
++	  continue;
++	}
++      a = val_to_num (p, l);
++      b = val_to_num (p, rhs);
++      r = (t[0] == '+') ? a + b : a - b;
++      val_free (l);
++      val_free (rhs);
++      l = val_num (r);
++    }
++  return l;
++}
++
++static int
++val_compare (struct val *l, struct val *r)
++{
++  if (l->have_num && r->have_num)
++    {
++      if (l->num < r->num) return -1;
++      if (l->num > r->num) return 1;
++      return 0;
++    }
++  return strcoll (l->str, r->str);
++}
++
++static int
++compare_op (const char *t)
++{
++  if (!t) return 0;
++  if (strcmp (t, "<") == 0)        return 1;
++  if (strcmp (t, "<=") == 0)       return 2;
++  if (strcmp (t, "=") == 0)        return 3;
++  if (strcmp (t, "==") == 0)       return 3;
++  if (strcmp (t, "!=") == 0)       return 4;
++  if (strcmp (t, ">=") == 0)       return 5;
++  if (strcmp (t, ">") == 0)        return 6;
++  return 0;
++}
++
++static struct val *
++parse_compare (struct parser *p, int evaluate)
++{
++  struct val *l = parse_addsub (p, evaluate);
++  int op;
++  while ((op = compare_op (peek (p))) != 0)
++    {
++      int cmp;
++      struct val *rhs;
++      consume (p);
++      rhs = parse_addsub (p, evaluate);
++      if (!evaluate)
++	{
++	  val_free (l);
++	  val_free (rhs);
++	  l = val_num (0);
++	  continue;
++	}
++      cmp = val_compare (l, rhs);
++      val_free (l);
++      val_free (rhs);
++      switch (op)
++	{
++	case 1: l = val_num (cmp <  0); break;
++	case 2: l = val_num (cmp <= 0); break;
++	case 3: l = val_num (cmp == 0); break;
++	case 4: l = val_num (cmp != 0); break;
++	case 5: l = val_num (cmp >= 0); break;
++	default: l = val_num (cmp > 0); break;
++	}
++    }
++  return l;
++}
++
++static struct val *
++parse_and (struct parser *p, int evaluate)
++{
++  struct val *l = parse_compare (p, evaluate);
++  while (match_op (p, "&"))
++    {
++      struct val *r = parse_compare (p, evaluate && val_truthy (l));
++      if (evaluate && val_truthy (l) && val_truthy (r))
++	{
++	  val_free (r);
++	}
++      else
++	{
++	  val_free (l);
++	  val_free (r);
++	  l = val_num (0);
++	}
++    }
++  return l;
++}
++
++static struct val *
++parse_or (struct parser *p, int evaluate)
++{
++  struct val *l = parse_and (p, evaluate);
++  while (match_op (p, "|"))
++    {
++      struct val *r = parse_and (p, evaluate && !val_truthy (l));
++      if (val_truthy (l))
++	{
++	  val_free (r);
++	}
++      else if (r->str[0] != '\0')
++	{
++	  val_free (l);
++	  l = r;
++	}
++      else
++	{
++	  val_free (l);
++	  val_free (r);
++	  l = val_num (0);
++	}
++    }
++  return l;
++}
++
++int
++expr_builtin (WORD_LIST *list)
++{
++  struct parser p;
++  struct val *v;
++  int truthy;
++
++  CHECK_HELPOPT (list);
++
++  /* Skip a single leading `--` separator. */
++  if (list && list->word && ISOPTION (list->word->word, '-'))
++    list = list->next;
++
++  if (list == 0)
++    {
++      builtin_error (_("syntax error: expression expected"));
++      return EXPR_INVALID;
++    }
++
++  p.tok = list;
++  p.err_status = 0;
++  if (setjmp (p.err_jmp) != 0)
++    return p.err_status;
++
++  v = parse_or (&p, 1);
++
++  if (p.tok != NULL)
++    {
++      val_free (v);
++      builtin_error (_("syntax error: unexpected `%s`"), p.tok->word->word);
++      return EXPR_INVALID;
++    }
++
++  printf ("%s\n", v->str);
++  truthy = val_truthy (v);
++  val_free (v);
++  return truthy ? EXECUTION_SUCCESS : EXECUTION_FAILURE;
++}
+-- 
+2.54.0.windows.1
+

--- a/bash/0009-tests-cover-the-expr-builtin.patch
+++ b/bash/0009-tests-cover-the-expr-builtin.patch
@@ -1,0 +1,361 @@
+From 85fa58d285af5710008aeef6c84baa6d33b20233 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 09:45:38 +0200
+Subject: [PATCH 09/N] tests: cover the `expr` builtin
+
+Add tests that exercise every operator and named operation supported by
+the `expr` builtin: arithmetic, the six comparison operators with both
+the numeric and the lexical paths, the short-circuiting `|` and `&`,
+the `:` regex match (with and without a `\(...\)` capture group, both
+matching and non-matching), `length`, `substr` (including the
+out-of-range edge cases POSIX requires to return ""), `index` and
+`match`. Each test prints its result through a helper that also prints
+the exit status, so the `.right` file pins down both.
+
+The error-case tests deliberately suppress stderr and check only the
+exit status. That makes the same `.right` file match both the builtin
+and `/usr/bin/expr.exe`, which is useful for cross-checking
+implementation parity: substitute `enable -n expr` for the
+keyword-loading line and the test runner exercises the external binary
+via `PATH` lookup against the same expected output.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ tests/expr.right | 124 ++++++++++++++++++++++++++++++++
+ tests/expr.tests | 182 +++++++++++++++++++++++++++++++++++++++++++++++
+ tests/run-expr   |   2 +
+ 3 files changed, 308 insertions(+)
+ create mode 100644 tests/expr.right
+ create mode 100644 tests/expr.tests
+ create mode 100644 tests/run-expr
+
+diff --git a/tests/expr.right b/tests/expr.right
+new file mode 100644
+index 0000000..eed3db9
+--- /dev/null
++++ b/tests/expr.right
+@@ -0,0 +1,124 @@
++[1] 0
++[1] 
++[0] abc
++[0] 1
++[0] 5
++[0] 6
++[0] 42
++[0] 3
++[0] 2
++[0] 7
++[0] 9
++[0] -2
++[0] 2147483648
++[1] 0
++[0] -2
++[0] 3
++[0] 9
++[0] 1
++[0] 1
++[0] 1
++[0] 1
++[0] 1
++[0] 1
++[0] 1
++[1] 0
++[0] 1
++[1] 0
++[0] 1
++[0] 1
++[1] 0
++[0] 1
++[0] 1
++[0] 1
++[1] 0
++[1] 0
++[1] 0
++[1] 0
++[1] 0
++[0] 1
++[0] foo
++[0] bar
++[0] bar
++[0] foo
++[1] 0
++[1] 0
++[1] 0
++[1] 0
++[1] 0
++[0] -1
++[0] 5
++[0] 5
++[1] 0
++[1] 0
++[1] 0
++[0] 5
++[1] 0
++[0] 3
++[1] 0
++[0] bcde
++[1] 
++[0] 123
++[1] 0
++[0] 3
++[0] 3
++[0] 2
++[0] 3
++[1] 0
++[1] 0
++[1] 0
++[1] 
++[0] a
++[0] a
++[0] expr
++[0] 5
++[1] 0
++[0] world
++[0] hello
++[1] 
++[1] 
++[0] 5
++[1] 0
++[0] b
++[0] 6
++[0] 3
++[1] 
++[1] 
++[0] 6
++[0] 7
++[0] 8
++[0] 1
++[0] 1
++[0] 1
++[0] 1
++[0] 5
++[0] 2
++[0] 5
++[0] 1
++[0] 21
++[0] 5
++[1] 0
++true-rc-0
++false-rc-nonzero
++no-match-rc-nonzero
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++rc=2
++[0] 8
++[0] -2
++[0] 1
++[1] 0
++[0] 1
++[1] 0
++rc=2
++[0] 1+2
+diff --git a/tests/expr.tests b/tests/expr.tests
+new file mode 100644
+index 0000000..3c4aaae
+--- /dev/null
++++ b/tests/expr.tests
+@@ -0,0 +1,182 @@
++#   This program is free software: you can redistribute it and/or modify
++#   it under the terms of the GNU General Public License as published by
++#   the Free Software Foundation, either version 3 of the License, or
++#   (at your option) any later version.
++#
++#   This program is distributed in the hope that it will be useful,
++#   but WITHOUT ANY WARRANTY; without even the implied warranty of
++#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++#   GNU General Public License for more details.
++#
++#   You should have received a copy of the GNU General Public License
++#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
++#
++# Make sure we exercise the builtin, not /usr/bin/expr.
++enable expr || { echo "expr builtin not available" >&2; exit 1; }
++
++# Helper: print the result and the exit status, so the .right file
++# pins both of them down.
++e()
++{
++	out=$(expr "$@")
++	rc=$?
++	printf '[%d] %s\n' "$rc" "$out"
++}
++
++# --- single-operand expressions -----------------------------------------
++e 0
++e ''
++e abc
++e 1
++
++# --- arithmetic ---------------------------------------------------------
++e 2 + 3
++e 10 - 4
++e 6 \* 7
++e 20 / 6
++e 20 % 6
++e 1 + 2 \* 3
++e \( 1 + 2 \) \* 3
++e -5 + 3
++e 2147483647 + 1
++e 1 - 1
++e 3 - 5
++e 02 + 1
++e 08 + 1
++
++# --- comparison: numeric vs lexical ------------------------------------
++e 2 = 2
++e 2 = 02			# numeric: equal
++e 2.34 \<= 2.40			# non-numeric: lexical
++e 2.34 \<= 2.4			# non-numeric: lexical, '4' > ''
++e abc = abc
++e abc \< abd
++e 5 \> 4
++e 5 != 5
++e 5 \>= 5
++e 4 \>= 5
++e 6 \>= 5
++e 3 \< 10			# numeric: 3 < 10, not lexical
++e 5 \< 4
++e -5 \< 3			# signed integer comparison
++e -2 \< -1
++e -0 = 0
++e 5 = 6				# false comparison pins stdout to '0'
++e 3 \>= 4
++e 9 \< 10abc			# mixed int/string: falls back to lexical
++e +5 = 5			# +5 is a string, not integer
++e ' 5' = 5			# whitespace disqualifies as integer
++e - = -				# bare minus is a string
++
++# --- logical | and & ----------------------------------------------------
++e foo \| bar
++e '' \| bar
++e 0 \| bar
++e foo \& bar
++e foo \& 0
++e '' \& bar
++e '' \| ''			# both null -> 0
++e 0 \| 0			# both zero -> 0
++e '' \| 0			# null left, zero right -> 0
++e -1 \| bar			# nonzero integer left -> return left
++e 2 + 3 \| bar			# evaluated left expression
++e 5 \& 7			# returns expr1, not expr2
++e 5 \& 0
++e '' \& ''
++e foo \& ''			# right null -> 0
++e 2 + 3 \& yes			# evaluated left expression in &
++e 1 - 1 \& yes			# left evaluates to zero -> 0
++
++# --- regex match: `:' operator -----------------------------------------
++e abc : 'a.c'			# no group: matched length
++e abc : 'x.c'			# no match, no group
++e abcdef : 'a\(.*\)f'		# group: captured substring
++e abc : 'x\(.*\)y'		# no match, with group: ''
++e foo123bar : '[a-z]*\([0-9]*\)'
++# `:' is left-anchored; the leading 'b' should not match
++e abc : 'b'
++e aaab : 'a*'			# * on single char
++e aaaa : 'a\{2,3\}'		# BRE interval
++e aaaa : 'a\{2\}'		# BRE exact count
++e abc : '[^x]*'			# bracket negation
++e aaa : 'a+'			# BRE: unescaped + is literal, no match
++e '' : '.*'			# empty string: zero-length match
++e abc : ''			# empty pattern: zero-length match
++e ac : 'a\(b*\)c'		# empty successful capture -> null
++e abcdef : '\(a\)\(b\)\(c\)'	# multiple captures: only \1 returned
++e ab : '\(a\)\(b\)'		# multiple captures: only \1 returned
++e "//usr/bin/expr" : '.*/\(.*\)'	# POSIX basename idiom
++
++# --- named operations --------------------------------------------------
++e length hello
++e length ''
++e substr 'hello world' 7 5
++e substr 'hello' 1 100
++e substr 'hello' 6 1
++e substr 'hello' 0 3
++e index 'hello world' 'wor'
++e index 'hello' 'xyz'
++e match abc 'a\(.*\)c'
++e match abcdef '[a-z]*'
++e index abcdef fc		# char-set semantics, not substring search
++e substr hello -1 3		# negative start -> null
++e substr hello 10 3		# start past end -> null
++
++# --- operator precedence ------------------------------------------------
++e 3 \* abc : 'a.'		# : tighter than *
++e 10 - 6 / 2			# / tighter than -
++e 10 - 6 % 4			# % tighter than -
++e 2 + 3 = 5			# + tighter than =
++e 1 + 2 = 3
++e 1 = 1 \& yes			# comparison tighter than &
++e 1 \| 0 \& 0			# & tighter than |: 1|(0&0)=1
++e "Xhello" : '.*' - 1		# POSIX length idiom: (: feeds -)
++
++# --- left-associativity -------------------------------------------------
++e 20 / 4 / 2
++e 10 - 3 - 2
++e 1 \< 2 \< 3			# chained comparisons: (1<2)=1, 1<3=1
++
++# --- grouping -----------------------------------------------------------
++e \( \( 1 + 2 \) \* \( 3 + 4 \) \)	# nested parens
++e \( 5 \)
++e \( 0 \)
++
++# --- exit status meaning -----------------------------------------------
++expr 1 \> 0 >/dev/null && echo true-rc-0
++expr 0 \> 1 >/dev/null || echo false-rc-nonzero
++expr foo : bar >/dev/null || echo no-match-rc-nonzero
++
++# --- error cases (exit status 2) ---------------------------------------
++# We only check the exit status, not the (implementation-specific) wording
++# of the error message, so that the same expectations match both the
++# builtin and /usr/bin/expr.
++expr 2>/dev/null; echo rc=$?
++expr 1 + 2>/dev/null; echo rc=$?
++expr \( 1 + 2 2>/dev/null; echo rc=$?
++expr foo + bar 2>/dev/null; echo rc=$?
++expr 1 / 0 2>/dev/null; echo rc=$?
++expr 1 % 0 2>/dev/null; echo rc=$?
++expr foo \* 2 2>/dev/null; echo rc=$?
++expr 1 = 2>/dev/null; echo rc=$?
++expr 1 + 2 3 2>/dev/null; echo rc=$?
++expr \( \) 2>/dev/null; echo rc=$?
++expr 1 + 2 \) 2>/dev/null; echo rc=$?
++expr '' + 1 2>/dev/null; echo rc=$?
++expr + 2>/dev/null; echo rc=$?
++
++# --- leading `--' --------------------------------------------------------
++e -- 5 + 3
++e -- -5 + 3
++
++# --- short-circuit evaluation -------------------------------------------
++e 1 '|' 1 / 0
++e 0 '&' 1 / 0
++e 1 '|' \( 0 '&' 1 / 0 \)
++e 0 '&' \( 1 '|' 1 / 0 \)
++
++# --- bare `length' with no argument -------------------------------------
++expr length 2>/dev/null; echo rc=$?
++
++# --- concatenated arg (no spaces) ---------------------------------------
++e 1+2
+diff --git a/tests/run-expr b/tests/run-expr
+new file mode 100644
+index 0000000..9089271
+--- /dev/null
++++ b/tests/run-expr
+@@ -0,0 +1,2 @@
++${THIS_SH} ./expr.tests 2>/dev/null > ${BASH_TSTOUT}
++diff ${BASH_TSTOUT} expr.right && rm -f ${BASH_TSTOUT}
+-- 
+2.54.0.windows.1
+

--- a/bash/0010-tests-import-the-GNU-coreutils-expr-test-suite.patch
+++ b/bash/0010-tests-import-the-GNU-coreutils-expr-test-suite.patch
@@ -1,0 +1,273 @@
+From 8f6bc42ccee15b0d40cf308a57254592d39cdacb Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Thu, 28 May 2026 11:11:06 +0200
+Subject: [PATCH 10/N] tests: import the GNU coreutils expr test suite
+
+While the main reason to implement a built-in `expr` in Bash is to
+accelerate Git's test suite, the built-in will be exposed to Git for
+Windows' users via the Git Bash. They will expect it to behave just like
+`/usr/bin/expr.exe` behaved, i.e. GNU semantics, not just POSIX ones.
+The intention of this commit is not only to demonstrate _almost_ feature
+parity with `/usr/bin/expr.exe` (i.e. the GNU coreutils variant), but
+also to document the gaps. Users who require the GNU `expr` behavior
+instead of the built-in `expr` one will need to work around this by
+disabling the built-in: `enable -n expr`.
+
+This commit adds `tests/expr-coreutils.tests`, a standalone Bash script
+with 96 test cases ported from the GNU coreutils `expr.pl` test
+definition (see the coreutils source under `tests/expr/expr.pl`). It
+exercises arithmetic, option handling, parenthesised subexpressions,
+string and integer edge cases, short-circuit evaluation, the three-way
+semantics of `|` with empty operands, anchored and newline-bearing regex
+matches, empty subexpression matches, BRE corner cases lifted from
+grep's `bre.tests`, and several error-only diagnostics.
+
+Tests fall into two categories. The `t(...)` helper checks both exit
+status and stdout. The `te(...)` helper only checks exit status, used
+for error cases where the exact diagnostic wording is
+implementation-defined and should not be pinned down. All 96 tests
+pass when `expr` resolves to `/usr/bin/expr` (GNU coreutils).
+
+Nine of those tests are marked as known expected failures
+(`KNOWN_XFAIL`) when run against the Bash builtin: `bre17`, `bre19`,
+`bre35`, `bre38`, `bre45`, `bre46`, `bre58`, `bre59`, `bre60`. They
+all probe BRE constructs that POSIX either does not specify or
+explicitly leaves undefined. None of the nine exercises behaviour
+that POSIX requires of a conforming `expr`.
+
+Concretely, the `bre45` and `bre46` patterns `a\{,2\}` and `a\{,\}`
+use the `\{,n\}` form, which is a GNU extension. POSIX (IEEE Std
+1003.1-2017, Base Definitions section 9.3.6 item 5,
+https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html)
+only defines `\{m\}`, `\{m,\}`, and `\{m,n\}`, where `m` and `n` are
+decimal integers; the leading `m` is mandatory. The `bre58`, `bre59`
+and `bre60` patterns `a\{1\}\{1\}`, `a*\{1\}` and `a\{1\}*` chain
+duplication operators back to back. POSIX 9.3.6 ends with the explicit
+sentence "The behavior of multiple adjacent duplication symbols (`*`
+and intervals) produces undefined results." The `bre17` and `bre19`
+patterns `\(\{1\}a\)` and `^\{1\}` apply `\{` with no preceding atom,
+which is again outside the POSIX grammar in 9.3.6 item 5 (an interval
+expression follows a BRE matching a single character, a subexpression,
+or a back-reference). The `bre35` and `bre38` patterns `a\(***\)b`
+and `***a` chain two or more `*` characters; POSIX 9.3.3 makes `*`
+special only after the first non-`^` atom, and the second and third
+`*` characters in `***` fall under the same "multiple adjacent
+duplication symbols" undefined-results clause as above.
+
+The builtin uses the MSYS2 runtime's BSD/Henry Spencer regex engine
+via `regcomp(3)` with `cflags == 0` (POSIX BRE). That engine
+hard-codes `REG_BADRPT` or `REG_BADBR` for each of the constructs
+above, which is one of the outcomes POSIX permits for undefined
+behaviour. GNU coreutils on the other hand links a bundled gnulib
+regex engine and calls `re_compile_pattern(...)` with the syntax mask
+`(RE_SYNTAX_POSIX_BASIC & ~RE_CONTEXT_INVALID_DUP & ~RE_NO_EMPTY_RANGES)`,
+which deliberately accepts these GNU extensions. Making the builtin
+match coreutils on the nine xfails would therefore require bundling
+the gnulib regex sources, not just a different `regcomp(3)` flag,
+and the patterns in question are POSIX-undefined to begin with. The
+xfail mechanism records them so the test script still exits cleanly
+while documenting the divergence.
+
+Run the suite with
+
+    cd tests
+    export PATH=/usr/bin:$PATH
+    ../bash.exe ./expr-coreutils.tests
+
+against the builtin, or substitute `/usr/bin/bash` for `../bash.exe`
+to run it against `/usr/bin/expr`.
+
+Note that this new script deviates from the existing `tests/run-*`
+scripts intentionally, to stay as close to the original tests in GNU
+coreutils as possible (to make validation or future synchronization
+easier).
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ tests/run-expr-coreutils | 173 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 173 insertions(+)
+ create mode 100755 tests/run-expr-coreutils
+
+diff --git a/tests/run-expr-coreutils b/tests/run-expr-coreutils
+new file mode 100755
+index 0000000..f9ebad8
+--- /dev/null
++++ b/tests/run-expr-coreutils
+@@ -0,0 +1,173 @@
++#!/bin/bash
++# Test cases extracted from GNU coreutils tests/expr/expr.pl
++# Adapted to run against the bash builtin or /usr/bin/expr.
++#
++# Each test: t NAME expected_exit expected_stdout ARGS...
++# For error-only tests (no stdout check): te NAME expected_exit ARGS...
++
++PASS=0 FAIL=0 XFAIL=0
++
++# Tests that fail because the builtin uses POSIX regcomp() which rejects
++# certain GNU BRE extensions (repeated intervals, \{,N\}, leading ***).
++# These pass with /usr/bin/expr (GNU coreutils) but not with the builtin.
++declare -A KNOWN_XFAIL=(
++  [bre17]=1 [bre19]=1 [bre35]=1 [bre38]=1 [bre45]=1
++  [bre46]=1 [bre58]=1 [bre59]=1 [bre60]=1
++)
++
++t () {
++  local name=$1 xexit=$2 xout=$3; shift 3
++  local out rc
++  out=$(expr "$@" 2>/dev/null); rc=$?
++  if [[ $rc -ne $xexit || "$out" != "$xout" ]]; then
++    if [[ ${KNOWN_XFAIL[$name]+set} ]]; then
++      ((XFAIL++)); return
++    fi
++    if [[ $rc -ne $xexit ]]; then
++      echo "FAIL $name: exit $rc (expected $xexit)"
++    else
++      echo "FAIL $name: out='$out' (expected '$xout')"
++    fi
++    ((FAIL++)); return
++  fi
++  ((PASS++))
++}
++
++# error tests: check exit code only, ignore exact diagnostic wording
++te () {
++  local name=$1 xexit=$2; shift 2
++  local rc
++  expr "$@" >/dev/null 2>&1; rc=$?
++  if [[ $rc -ne $xexit ]]; then
++    if [[ ${KNOWN_XFAIL[$name]+set} ]]; then
++      ((XFAIL++)); return
++    fi
++    echo "FAIL $name: exit $rc (expected $xexit)"
++    ((FAIL++)); return
++  fi
++  ((PASS++))
++}
++
++echo "=== Arithmetic ==="
++t a   0 11  5 + 6
++t b   0 -1  5 - 6
++t c   0 30  5 '*' 6
++t d   0 16  100 / 6
++t e   0 4   100 % 6
++t f   0 1   3 + -2
++t g   0 -4  -2 + -2
++
++echo "=== Option handling (--) ==="
++t opt1 0 1   -- -11 + 12
++t opt2 0 1   -11 + 12
++t opt3 0 1   -- -1 + 2
++t opt4 0 1   -1 + 2
++t opt5 0 4   -- 2 + 2
++
++echo "=== Parentheses ==="
++t paren1 0 4   '(' 100 % 6 ')'
++t paren2 0 -4  '(' 100 % 6 ')' - 8
++t paren3 0 -6  9 / '(' 100 % 6 ')' - 8
++t paren4 0 -2  9 / '(' '(' 100 % 6 ')' - 8 ')'
++t paren5 0 13  9 + '(' 100 % 6 ')'
++
++echo "=== String/integer edge cases ==="
++t 0bang  1 0   00 '<' '0!'
++t 00     1 00  00
++t minus0 1 -0  -0
++
++echo "=== Short-circuit evaluation ==="
++t andand    1 0  0 '&' 1 / 0
++t oror      0 1  1 '|' 1 / 0
++t or-paren  0 1  1 '|' '(' 1 / 0 ')'
++t and-paren 1 0  0 '&' '(' 1 / 0 ')'
++t or-nested  0 1  1 '|' '(' 0 '&' '(' 1 / 0 ')' ')'
++t and-nested 1 0  0 '&' '(' 1 '|' '(' 1 / 0 ')' ')'
++
++echo "=== Or with empty strings ==="
++t orempty 1 0  "" '|' ""
++
++echo "=== Anchor/newline in regex ==="
++# 'a\nb' : 'a$' should NOT match (anchors do not match embedded newlines)
++t anchor 1 0  "$(printf 'a\nb')" : 'a$'
++
++echo "=== Empty subexpression match ==="
++t emptysub 1 ""  a : '\(b\)*'
++
++echo "=== BRE tests (from grep/tests/bre.tests) ==="
++t bre1  0 b     abc : 'a\(b\)c'
++t bre2  0 2     'a(' : 'a('
++te bre3 2       _ : 'a\('
++te bre4 2       _ : 'a\(b'
++t bre5  0 3     'a(b' : 'a(b'
++t bre6  0 2     'a)' : 'a)'
++te bre7 2       _ : 'a\)'
++te bre8 2       _ : '\)'
++t bre9  1 ""    ab : 'a\(\)b'
++t bre10 0 3     'a^b' : 'a^b'
++t bre11 0 3     'a$b' : 'a$b'
++t bre12 1 ""    "" : '\($\)\(^\)'
++t bre13 0 b     b : 'a*\(^b$\)c*'
++# bre14 and bre15 test multi-expression chaining - skip, non-standard
++t bre16 1 ""    abc : '\(\)'
++t bre17 0 '{1}a' '{1}a' : '\(\{1\}a\)'
++# bre18 tests multi-expression chaining - skip
++t bre19 0 3     '{1}' : '^\{1\}'
++t bre20 0 1     '{' : '{'
++t bre21 1 ""    abbcbd : 'a\(b*\)c\1d'
++t bre22 1 ""    abbcbbbd : 'a\(b*\)c\1d'
++t bre23 1 ""    abc : '\(.\)\1'
++t bre24 0 cc    abbccd : 'a\(\([bc]\)\2\)*d'
++t bre25 1 ""    abbcbd : 'a\(\([bc]\)\2\)*d'
++t bre26 0 bbb   abbbd : 'a\(\(b\)*\2\)*d'
++t bre27 0 a     aabcd : '\(a\)\1bcd'
++t bre28 0 a     aabcd : '\(a\)\1bc*d'
++t bre29 0 a     aabd : '\(a\)\1bc*d'
++t bre30 0 a     aabcccd : '\(a\)\1bc*d'
++t bre31 0 a     aabcccd : '\(a\)\1bc*[ce]d'
++t bre32 0 a     aabcccd : '\(a\)\1b\(c\)*cd$'
++t bre33 0 '*'   'a*b' : 'a\(*\)b'
++t bre34 1 ""    ab : 'a\(**\)b'
++t bre35 1 ""    ab : 'a\(***\)b'
++t bre36 0 2     '*a' : '*a'
++t bre37 0 1     a : '**a'
++t bre38 0 1     a : '***a'
++t bre39 0 2     ab : 'a\{1\}b'
++t bre40 0 2     ab : 'a\{1,\}b'
++t bre41 0 3     aab : 'a\{1,2\}b'
++te bre42 2      _ : 'a\{1'
++te bre43 2      _ : 'a\{1a'
++te bre44 2      _ : 'a\{1a\}'
++t bre45 0 1     a : 'a\{,2\}'
++t bre46 0 1     a : 'a\{,\}'
++te bre47 2      _ : 'a\{1,x\}'
++te bre48 2      _ : 'a\{1,x'
++# bre49: {32768} - implementation-defined overflow
++te bre50 2      _ : 'a\{1,0\}'
++t bre51 0 2     acabc : '.*ab\{0,0\}c'
++t bre52 0 3     abcac : 'ab\{0,1\}c'
++t bre53 0 4     abbcac : 'ab\{0,3\}c'
++t bre54 0 3     abcac : '.*ab\{1,1\}c'
++t bre55 0 3     abcac : '.*ab\{1,3\}c'
++t bre56 0 4     abbcabc : '.*ab\{2,2\}c'
++t bre57 0 4     abbcabc : '.*ab\{2,4\}c'
++t bre58 0 1     aa : 'a\{1\}\{1\}'
++t bre59 0 2     aa : 'a*\{1\}'
++t bre60 0 2     aa : 'a\{1\}*'
++t bre61 1 ""    acd : 'a\(b\)?c\1d'
++t bre62 0 2     -- -5 : '-\{0,1\}[0-9]*$'
++
++echo "=== Error cases ==="
++te fail-a 2    3 + -
++te fail-c 2
++te se0    2    9 9
++te se1    2    2 a
++te se2    2    2 '+'
++te se3    2    2 :
++te se4    2    length
++te se5    2    '(' 2
++te se6    2    '(' 2 a
++
++echo ""
++echo "Total: $((PASS+FAIL+XFAIL)) tests, $PASS passed, $FAIL failed, $XFAIL xfail (known)"
++[[ $FAIL -eq 0 ]]
+-- 
+2.54.0.windows.1
+

--- a/bash/0011-jobs-add-register_spawned_child-.-for-non-fork-child.patch
+++ b/bash/0011-jobs-add-register_spawned_child-.-for-non-fork-child.patch
@@ -1,0 +1,120 @@
+From dd4c2b321ba14c30b43366f1601fb16a473bedb4 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 5 May 2026 10:17:33 +0200
+Subject: [PATCH 11/N] jobs: add `register_spawned_child(...)` for non-fork
+ child registration
+
+`make_child(...)` interleaves two responsibilities: it `fork(...)`s and
+then, on the parent side, registers the new child with bash's job
+tables (`setpgid(...)`, `add_process(...)`, `last_made_pid`, the
+asynchronous-jobs list, the per-PID bookkeeping counters). On Cygwin /
+MSYS2 the upcoming spawnve-based fast path in `execute_disk_command(...)`
+needs the registration half without the fork half, because the child
+process already exists (`spawnve(...)` returned its pid) by the time
+the registration would otherwise run.
+
+Extracting that registration half from `make_child(...)` cleanly is not
+practical: the parent-side bookkeeping is tightly interleaved with
+post-`fork(...)` cleanup, signal-handler state, and child-side
+branches. A clean refactor would touch every caller. Instead introduce
+a separate entry point `register_spawned_child(...)` that recapitulates
+the parent-side bookkeeping for an already-spawned pid.
+
+The helper assumes the caller has already arranged the appropriate
+signal blocking around the spawn and the child startup; it performs
+the `setpgid(...)`, `add_process(...)`, `last_made_pid` update and the
+job-table dance that the parent branch of `make_child(...)` does, and
+nothing else.
+
+Guarded by `__CYGWIN__` since this exists solely to support the
+`spawnve(...)` path. On other platforms `make_child(...)` remains the
+only entry point and this code would be dead weight. The guard is also
+forward-looking: there are no plans to upstream the fast path to GNU
+Bash, which targets POSIX systems where `fork(...)` is cheap.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ jobs.c | 52 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ jobs.h |  3 +++
+ 2 files changed, 55 insertions(+)
+
+diff --git a/jobs.c b/jobs.c
+index 528c90f..a2465b1 100644
+--- a/jobs.c
++++ b/jobs.c
+@@ -2501,6 +2501,58 @@ make_child (char *command, int flags)
+   return (pid);
+ }
+ 
++#ifdef __CYGWIN__
++/* Register a child created by spawnv() (or any non-fork mechanism) in
++   the job table.  This mirrors the parent-side bookkeeping of
++   make_child(), but assumes the caller has already arranged signal
++   blocking around the spawn and the child's process startup.
++   Returns PID. */
++pid_t
++register_spawned_child (pid_t pid, char *command, int flags)
++{
++  PROCESS *child;
++  int async_p;
++
++  async_p = (flags & FORK_ASYNC);
++
++  if (job_control)
++    {
++      if (pipeline_pgrp == 0)
++	pipeline_pgrp = pid;
++      if ((flags & FORK_NOJOB) == 0 && setpgid (pid, pipeline_pgrp) < 0)
++        sys_error (_("child setpgid (%ld to %ld)"), (long)pid, (long)pipeline_pgrp);
++    }
++  else if (pipeline_pgrp == 0)
++    pipeline_pgrp = shell_pgrp;
++
++  /* Place all processes into the jobs array regardless of the
++     state of job_control. */
++  child = add_process (command, pid);
++
++  if (flags & FORK_PROCSUB)
++    child->flags |= PROC_PROCSUB;
++  if (flags & FORK_COMSUB)
++    child->flags |= PROC_COMSUB;
++
++  if (async_p)
++    last_asynchronous_pid = pid;
++#if defined (RECYCLES_PIDS)
++  else if (last_asynchronous_pid == pid)
++    last_asynchronous_pid = 1;
++#endif
++
++  delete_old_job (pid);
++  bgp_delete (pid);
++
++  last_made_pid = pid;
++
++  js.c_totforked++;
++  js.c_living++;
++
++  return pid;
++}
++#endif /* __CYGWIN__ */
++
+ /* These two functions are called only in child processes. */
+ void
+ ignore_tty_job_signals (void)
+diff --git a/jobs.h b/jobs.h
+index 64509e2..7b99881 100644
+--- a/jobs.h
++++ b/jobs.h
+@@ -295,6 +295,9 @@ extern void list_stopped_jobs (int);
+ extern void list_running_jobs (int);
+ 
+ extern pid_t make_child (char *, int);
++#ifdef __CYGWIN__
++extern pid_t register_spawned_child (pid_t, char *, int);
++#endif
+ 
+ extern int get_tty_state (void);
+ extern int set_tty_state (void);
+-- 
+2.54.0.windows.1
+

--- a/bash/0012-execute_cmd-introduce-nofastspawn-shopt-and-fast_spa.patch
+++ b/bash/0012-execute_cmd-introduce-nofastspawn-shopt-and-fast_spa.patch
@@ -1,0 +1,151 @@
+From 6ab179595431df0e0aab9a5965af900e68dd4b9b Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 29 May 2026 16:43:47 +0200
+Subject: [PATCH 12/N] execute_cmd: introduce `nofastspawn` shopt and
+ `fast_spawn_command(...)` scaffold
+
+A subsequent commit on this branch will introduce a spawnve-based fast
+path for synchronous external commands on MSYS2/Cygwin, where
+`fork(...)` is expensive enough that bypassing it for the common case
+of running a single external program is worth a substantial chunk of
+machinery. That machinery wants two things from day one, before any
+fast-path code actually executes: a runtime escape hatch in case a
+regression slips into a release, and a single dedicated call site in
+`execute_disk_command(...)` that other commits can extend incrementally.
+
+This commit puts both in place as a scaffold. The `nofastspawn` shopt
+controls a global `nofastspawn_set` flag (off by default). When set, the
+future fast path declines immediately and the caller falls through to
+the regular `fork(...)` + `exec(...)` path, giving users an in-shell
+knob to sidestep a fast-path regression without having to downgrade the
+bash package. As no fast-spawn functionality is in place yet, the
+scaffold function `fast_spawn_command(...)` always declines for now.
+
+`fast_spawn_command(...)`'s signature is fixed in this scaffold to
+what the upcoming feature commits need (`command`, `words`,
+`redirects`, `command_line`, `pipe_in`, `pipe_out`, `async`,
+`fds_to_close`, `cmdflags`) so that the call site in
+`execute_disk_command(...)` does not have to be rewritten each time a
+new argument is plumbed in.
+
+Guarded by `__CYGWIN__` since the fast path exists solely for the
+MSYS2/Cygwin emulated `fork(...)` cost. On other platforms the
+scaffold compiles away entirely and `execute_disk_command(...)`
+continues to call `make_child(...)` directly.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ builtins/shopt.def |  7 +++++++
+ execute_cmd.c      | 51 ++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 58 insertions(+)
+
+diff --git a/builtins/shopt.def b/builtins/shopt.def
+index cf6f6be..0bedcab 100644
+--- a/builtins/shopt.def
++++ b/builtins/shopt.def
+@@ -129,6 +129,10 @@ int expand_once_flag;
+ extern int syslog_history;
+ #endif
+ 
++#if defined (__CYGWIN__)
++extern int nofastspawn_set;
++#endif
++
+ static void shopt_error (char *);
+ 
+ static int set_shellopts_after_change (char *, int);
+@@ -249,6 +253,9 @@ static struct {
+   { "nocaseglob", &glob_ignore_case, (shopt_set_func_t *)NULL },
+   { "nocasematch", &match_ignore_case, (shopt_set_func_t *)NULL },
+   { "noexpand_translation", &singlequote_translations, (shopt_set_func_t *)NULL },
++#if defined (__CYGWIN__)
++  { "nofastspawn", &nofastspawn_set, (shopt_set_func_t *)NULL },
++#endif
+   { "nullglob",	&allow_null_glob_expansion, (shopt_set_func_t *)NULL },
+   { "patsub_replacement", &patsub_replacement, (shopt_set_func_t *)NULL },
+ #if defined (PROGRAMMABLE_COMPLETION)
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 070f511..b45d472 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -180,6 +180,12 @@ static void execute_subshell_builtin_or_function (WORD_LIST *, REDIRECT *,
+ static int execute_disk_command (WORD_LIST *, REDIRECT *, char *,
+ 				      int, int, int, struct fd_bitmap *, int);
+ 
++#ifdef __CYGWIN__
++static pid_t fast_spawn_command (char *, WORD_LIST *, REDIRECT *,
++				 char *, int, int, int,
++				 struct fd_bitmap *, int);
++#endif
++
+ static char *getinterp (char *, int, int *);
+ static void initialize_subshell (void);
+ static int execute_in_subshell (COMMAND *, int, int, int, struct fd_bitmap *);
+@@ -198,6 +204,14 @@ static int execute_intern_function (WORD_DESC *, FUNCTION_DEF *);
+    so that reader_loop can set it to zero before executing a command. */
+ int stdin_redir;
+ 
++#ifdef __CYGWIN__
++/* When set via `shopt -s nofastspawn', the spawnve()-based fast path for
++   external commands is bypassed and execution falls through to the regular
++   fork()+exec() path.  Provides a runtime escape hatch for users who hit
++   a fast-path regression. */
++int nofastspawn_set = 0;
++#endif
++
+ /* The name of the command that is currently being executed.
+    `test' needs this, for example. */
+ char *this_command_name;
+@@ -5831,7 +5845,18 @@ execute_disk_command (WORD_LIST *words, REDIRECT *redirects, char *command_line,
+   else
+     {
+       fork_flags = async ? FORK_ASYNC : 0;
++#ifdef __CYGWIN__
++      pid = (command != 0)
++	      ? fast_spawn_command (command, words, redirects,
++				    command_line, pipe_in,
++				    pipe_out, async, fds_to_close,
++				    cmdflags)
++	      : (pid_t)-1;
++      if (pid == (pid_t)-1)
++	pid = make_child (p = savestring (command_line), fork_flags);
++#else
+       pid = make_child (p = savestring (command_line), fork_flags);
++#endif
+     }
+ 
+   if (pid == 0)
+@@ -6407,3 +6432,29 @@ do_piping (int pipe_in, int pipe_out)
+ #endif /* __CYGWIN__ */
+     }
+ }
++
++#ifdef __CYGWIN__
++/* Spawnve-based fast path for synchronous external commands on
++   MSYS2/Cygwin.  This is a scaffold: the function always declines.
++   Subsequent commits fill in actual fast-path support for the common
++   cases (plain externals, simple redirections, pipelines, heredocs,
++   async, etc.).  The scaffold exists from the start of the patch
++   series so that the user-visible escape hatch (the `nofastspawn'
++   shopt) and the caller's decline-handling logic are in place before
++   any fast-path code executes. */
++static pid_t
++fast_spawn_command (char *command, WORD_LIST *words,
++		    REDIRECT *redirects, char *command_line,
++		    int pipe_in, int pipe_out, int async,
++		    struct fd_bitmap *fds_to_close, int cmdflags)
++{
++  /* Runtime escape hatch: when `shopt -s nofastspawn' is in effect,
++     always decline so the caller falls through to the regular
++     fork()+exec() path.  Useful to verify whether an issue is caused
++     by the fast path. */
++  if (nofastspawn_set)
++    return (pid_t)-1;
++  /* No fast-path implementation yet.  Decline. */
++  return (pid_t)-1;
++}
++#endif /* __CYGWIN__ */
+-- 
+2.54.0.windows.1
+

--- a/bash/0013-execute_cmd-introduce-FAST_SPAWN_-sentinels.patch
+++ b/bash/0013-execute_cmd-introduce-FAST_SPAWN_-sentinels.patch
@@ -1,0 +1,80 @@
+From 361be1820aa3a207de0d84de0885ce0c24f5c342 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 29 May 2026 16:48:43 +0200
+Subject: [PATCH 13/N] execute_cmd: introduce `FAST_SPAWN_*` sentinels
+
+Distinguish the return values of `fast_spawn_command()` to report
+precisely whether the fast-spawn code path was _declined_ or whether it
+_failed_. This is important to be able to avoid trying the slow path
+when the fast path failed, and to set the exit code correctly.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 31 +++++++++++++++++++++++++++----
+ 1 file changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index b45d472..86637c7 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -181,6 +181,19 @@ static int execute_disk_command (WORD_LIST *, REDIRECT *, char *,
+ 				      int, int, int, struct fd_bitmap *, int);
+ 
+ #ifdef __CYGWIN__
++/* Sentinels to distinguish between a declined vs a failed fast-spawn. */
++#define FAST_SPAWN_DECLINE	((pid_t)-1)	/* not eligible / not
++						   attempted; caller should
++						   fall back to the regular
++						   fork+exec path. */
++#define FAST_SPAWN_FAILED	((pid_t)-2)	/* parent-side redirection
++						   or pipe setup failed and
++						   the diagnostic has already
++						   been printed; caller should
++						   set last_command_exit_value
++						   to EXECUTION_FAILURE and
++						   NOT retry via fork+exec. */
++
+ static pid_t fast_spawn_command (char *, WORD_LIST *, REDIRECT *,
+ 				 char *, int, int, int,
+ 				 struct fd_bitmap *, int);
+@@ -5846,13 +5859,23 @@ execute_disk_command (WORD_LIST *words, REDIRECT *redirects, char *command_line,
+     {
+       fork_flags = async ? FORK_ASYNC : 0;
+ #ifdef __CYGWIN__
++      /* Try the MSYS2/Cygwin spawnve()-based fast path before falling
++	 back to fork()+execve().  The helper may return a positive pid
++	 (registered child), FAST_SPAWN_DECLINE (fall through to
++	 make_child), or FAST_SPAWN_FAILED (parent-side preparation
++	 failed and a diagnostic has been printed; do not retry). */
+       pid = (command != 0)
+ 	      ? fast_spawn_command (command, words, redirects,
+ 				    command_line, pipe_in,
+ 				    pipe_out, async, fds_to_close,
+ 				    cmdflags)
+-	      : (pid_t)-1;
+-      if (pid == (pid_t)-1)
++	      : FAST_SPAWN_DECLINE;
++      if (pid == FAST_SPAWN_FAILED)
++	{
++	  result = last_command_exit_value = EXECUTION_FAILURE;
++	  goto parent_return;
++	}
++      if (pid == FAST_SPAWN_DECLINE)
+ 	pid = make_child (p = savestring (command_line), fork_flags);
+ #else
+       pid = make_child (p = savestring (command_line), fork_flags);
+@@ -6453,8 +6476,8 @@ fast_spawn_command (char *command, WORD_LIST *words,
+      fork()+exec() path.  Useful to verify whether an issue is caused
+      by the fast path. */
+   if (nofastspawn_set)
+-    return (pid_t)-1;
++    return FAST_SPAWN_DECLINE;
+   /* No fast-path implementation yet.  Decline. */
+-  return (pid_t)-1;
++  return FAST_SPAWN_DECLINE;
+ }
+ #endif /* __CYGWIN__ */
+-- 
+2.54.0.windows.1
+

--- a/bash/0014-execute_cmd-implement-fast-spawn-path-for-synchronou.patch
+++ b/bash/0014-execute_cmd-implement-fast-spawn-path-for-synchronou.patch
@@ -1,0 +1,196 @@
+From 2b47c1f145b0fa8c73087bde242f8552e92e51b7 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 5 May 2026 10:14:22 +0200
+Subject: [PATCH 14/N] execute_cmd: implement fast-spawn path for synchronous
+ external commands
+
+On Cygwin (and therefore MSYS2, on which Git for Windows is built),
+`fork()` must emulate POSIX copy-on-write semantics by snapshotting the
+parent's address space. That is by far the most expensive part of
+spawning a child process; an empirical microbenchmark shows ~30ms per
+`fork()` & `execve()` versus ~14ms per `spawnve()`, and 200 sequential
+externals from Bash take ~7.5s with the unmodified bash versus ~3.4s
+with this change, a 2.2-2.5x speedup that compounds heavily over a full
+Git test run, where each `test_expect_success` goes through dozens of
+cheap externals like `/usr/bin/true`.
+
+Add a fast-spawn path for plain external commands with no pipes, no
+redirections, no async, no `CMD_NO_FORK`, and no `fds_to_close`. In that
+case it calls `spawnve(_P_NOWAIT, ...)` instead, which lowers to
+`CreateProcess()` directly on Windows.
+
+The helper does not replace bash's job-tracking machinery; it only
+substitutes for the `fork()` & `execve()` pair. The flow closely mirrors
+what `make_child()` does on the parent side.
+
+The caller's existing
+
+    if (already_making_children && pipe_out == NO_PIPE)
+        wait_for (last_made_pid, 0);
+
+path then runs unchanged, so `$?`, the `ERR` trap, `set -e`, command
+substitution, `PIPESTATUS` for the trivial case and friends keep
+working exactly as for forked children.
+
+The `_P_NOWAIT` flag is used rather than `_P_WAIT` because
+`spawnve(_P_WAIT, ...)`, tempting as it is for returning the child's
+exit status directly, bypasses `wait_for()` / `waitchld()` /
+`stop_pipeline()` and the `PIPESTATUS` / `ERR`-trap machinery, and
+cannot represent exit-by-signal accurately (only the low byte fits in
+the 0..255 return value). Using `_P_NOWAIT` plus a real registered pid
+lets Bash treat the spawned child as indistinguishable from a forked
+one.
+
+The excluded conditions each have a specific reason. Pipes and
+redirections require fd surgery that the regular path does in the
+post-fork child; supporting them on the spawn path means pre-arranging
+the fds in the parent and then restoring them, which is straightforward
+but deserves its own commit. Async (`&`) needs slightly different
+bookkeeping (the child's pid becomes `$!` and is added to the
+asynchronous-jobs list). `CMD_NO_FORK` means the caller intends to skip
+the fork entirely and exec in place, which `spawnve()` cannot match.
+`fds_to_close` is the bitmap of pipe fds inherited from an enclosing
+pipeline that the child must not see; the regular path closes them in
+the child after `fork()`, but a spawned child inherits all open fds
+without that hook. All of these are addressable in follow-up commits.
+
+One ownership detail worth flagging for future maintainers:
+`strvec_from_word_list()` returns an argv whose entries alias the
+`WORD_LIST`'s strings when its `alloc` parameter is 0. That is fine for
+the regular path because the `alloc == 0` callers run in the post-fork
+child where the subsequent `execve()` makes any double-free moot.
+`fast_spawn_command()` runs in the parent, so it must pass `alloc = 1`
+to get a deeply-copied argv; otherwise `strvec_dispose()` would free
+strings still owned by `words`, and the immediately following
+`dispose_words()` at `parent_return` would double-free them, producing
+`SIGABRT` inside `dispose_words()` several stack frames deep into the
+malloc arena's consistency check.  Vanilla bash has no in-tree caller of
+`strvec_from_word_list()` with `alloc = 1` plus parent-side disposal, so
+the convention is not documented anywhere upstream.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 88 +++++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 79 insertions(+), 9 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 86637c7..18b53f4 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -94,6 +94,10 @@ extern int errno;
+ 
+ #include "input.h"
+ 
++#if defined (__CYGWIN__)
++#  include <process.h>		/* spawnve, _P_NOWAIT */
++#endif
++
+ #if defined (ALIAS)
+ #  include "alias.h"
+ #endif
+@@ -6458,26 +6462,92 @@ do_piping (int pipe_in, int pipe_out)
+ 
+ #ifdef __CYGWIN__
+ /* Spawnve-based fast path for synchronous external commands on
+-   MSYS2/Cygwin.  This is a scaffold: the function always declines.
+-   Subsequent commits fill in actual fast-path support for the common
+-   cases (plain externals, simple redirections, pipelines, heredocs,
+-   async, etc.).  The scaffold exists from the start of the patch
+-   series so that the user-visible escape hatch (the `nofastspawn'
+-   shopt) and the caller's decline-handling logic are in place before
+-   any fast-path code executes. */
++   MSYS2/Cygwin.  Uses `spawnve(...)`, which lowers to `CreateProcess(...)`
++   directly on Windows; that is roughly twice as fast as
++   `fork(...)` + `execve(...)` because Cygwin's `fork(...)` has to
++   emulate POSIX copy-on-write semantics by snapshotting the parent's
++   address space.
++
++   On success returns the pid of the new child, already registered with
++   the job table so the caller's normal `wait_for(last_made_pid)` path
++   reaps it.  Returns `FAST_SPAWN_DECLINE` if the command cannot be
++   handled by the fast path (pipes, redirections, async, `CMD_NO_FORK`,
++   `fds_to_close`, or `shopt -s nofastspawn`), in which case the
++   caller must fall back to `make_child(...)`.  Subsequent commits
++   extend the fast path to cover more cases (redirections, pipelines,
++   heredocs, async, ...). */
+ static pid_t
+ fast_spawn_command (char *command, WORD_LIST *words,
+ 		    REDIRECT *redirects, char *command_line,
+ 		    int pipe_in, int pipe_out, int async,
+ 		    struct fd_bitmap *fds_to_close, int cmdflags)
+ {
++  char **args;
++  pid_t pid;
++  sigset_t set, oset;
++  int fork_flags;
++
+   /* Runtime escape hatch: when `shopt -s nofastspawn' is in effect,
+      always decline so the caller falls through to the regular
+      fork()+exec() path.  Useful to verify whether an issue is caused
+      by the fast path. */
+   if (nofastspawn_set)
+     return FAST_SPAWN_DECLINE;
+-  /* No fast-path implementation yet.  Decline. */
+-  return FAST_SPAWN_DECLINE;
++
++  /* Conditions we don't yet handle.  Bail out and let make_child do it. */
++  if (pipe_in != NO_PIPE || pipe_out != NO_PIPE)
++    return FAST_SPAWN_DECLINE;
++  if (redirects)
++    return FAST_SPAWN_DECLINE;
++  if (async)
++    return FAST_SPAWN_DECLINE;
++  if (cmdflags & CMD_NO_FORK)
++    return FAST_SPAWN_DECLINE;
++
++  /* If there are inherited pipe fds that the child must not see,
++     fall back; the regular path closes them in the child after fork. */
++  if (fds_to_close)
++    {
++      int i;
++      for (i = 0; i < fds_to_close->size; i++)
++	if (fds_to_close->bitmap[i])
++	  return FAST_SPAWN_DECLINE;
++    }
++
++  /* Mirror make_child's signal blocking around the spawn so that SIGCHLD
++     for the new child is held until we have registered it in the job
++     table.  Otherwise waitchld() could fire before add_process(). */
++  sigemptyset (&set);
++  sigaddset (&set, SIGCHLD);
++  sigaddset (&set, SIGINT);
++  sigaddset (&set, SIGTERM);
++  sigemptyset (&oset);
++  sigprocmask (SIG_BLOCK, &set, &oset);
++
++  making_children ();
++
++  args = strvec_from_word_list (words, 1, 0, (int *)NULL);
++
++  pid = spawnve (_P_NOWAIT, command, (const char * const *)args,
++		 (const char * const *)export_env);
++
++  strvec_dispose (args);
++
++  if (pid < 0)
++    {
++      /* spawnve failed; restore signals and fall back to fork+exec. */
++      sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
++      return FAST_SPAWN_DECLINE;
++    }
++
++  fork_flags = async ? FORK_ASYNC : 0;
++  register_spawned_child (pid, savestring (command_line), fork_flags);
++
++  /* Unblock signals now that the child is registered; a pending SIGCHLD
++     will be delivered and waitchld() will find the child in the job
++     table just as it would for a forked one. */
++  sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
++
++  return pid;
+ }
+ #endif /* __CYGWIN__ */
+-- 
+2.54.0.windows.1
+

--- a/bash/0015-execute_cmd-handle-simple-redirections-in-the-spawnv.patch
+++ b/bash/0015-execute_cmd-handle-simple-redirections-in-the-spawnv.patch
@@ -1,0 +1,298 @@
+From 8354e1ee464abdf329266a26927daf6fbd5860a1 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 15:58:43 +0200
+Subject: [PATCH 15/N] execute_cmd: handle simple redirections in the spawnve
+ fast path
+
+Extend the fast-spawn path to handle trivial redirections (`>file`,
+`<file`, `>>file`, `>|file`, `&>file`, `&>>file`, `<>file`, `<&N`,
+`>&N`, `<&-`, `>&-`) on fd 0/1/2 in the parent process before
+`spawnve()` and undo them afterwards. The fork path applies redirections
+in the post-fork child where the kernel has given it a private fd table;
+the fast-spawn path has no such hook, so it leans on Bash's existing
+`RX_UNDOABLE` machinery to capture inverse operations and replay them
+via `cleanup_redirects()` after the child has been spawned and inherited
+the redirected fds.
+
+A microbenchmark of 200 sequential externals each doing `>/dev/null
+2>&1` drops from ~8.0s to ~3.2s, the same 2.4x speedup the simple
+synchronous case already enjoys. The test-suite-typical `cmd >/dev/null
+2>&1` pattern is the hot case for this extension.
+
+The redirect set accepted is deliberately conservative. Three classes of
+hazards inform the per-redirect filter. First, `REDIR_VARASSIGN` (the
+`{var}<file` form) binds a shell variable in the current process; the
+regular path performs that mutation in the child where it disappears
+with it, so performing it in the parent would leak a variable
+assignment. Second, redirector fds >= 3: `do_redirections()` under
+`RX_UNDOABLE` dups the original fd into a save fd before applying the
+redirect, and for fd 0/1/2 that save fd is forced close-on-exec, but for
+higher fds it is not unconditionally so, so the spawned child can
+inherit a stray handle. The correct fix is to walk the new undo list and
+force `FD_CLOEXEC` on each save fd before `spawnve()`; that is more
+invasive than this initial cut warrants and bailing out for fd >= 3 is
+preferred for now. Third, process substitution (`<(cmd)`, `>(cmd)`):
+`redirection_expand()` performs word expansion which can call
+`process_substitute()`, which itself calls `make_child()` to fork off
+the substitution helper. In the parent that helper would become a child
+of the main shell rather than of the (would-be) forked external command,
+with substantial follow-on bookkeeping for procsub tracking, FIFO and
+`/dev/fd` lifetime, and `SIGCHLD` delivery (currently blocked when the
+helper would be forked). Process substitution is detected by the leading
+`<(` or `>(` of the redirectee word and bailed out.
+
+The list of supported `r_instruction` values is restricted to filename
+redirections (`r_input_direction`, `r_output_direction`,
+`r_appending_to`, `r_input_output`, `r_output_force`, `r_err_and_out`,
+`r_append_err_and_out`) and constant-fd duplications and closes
+(`r_duplicating_input`, `r_duplicating_output`, `r_close_this`).
+Word-form duplications (`r_duplicating_input_word`,
+`r_duplicating_output_word`) and the four move-fd instructions are
+excluded; they involve word expansion or reorder fds in ways the simple
+save/restore protocol does not handle. Heredocs and here-strings are
+also excluded; they allocate temp files that on a crash between
+`do_redirections()` and `cleanup_redirects()` could leak.
+
+Two undo-list globals require save-and-restore, not just one:
+`redirection_undo_list` (the parent-side fd-restoration list) and
+`exec_redirection_undo_list` (used by `exec >file` to commit
+redirections across an exec). `do_redirections()` under `RX_UNDOABLE`
+disposes of any existing list in either global at entry, so the caller's
+pending undos must be moved to local variables before the call and
+restored afterwards. `exec_redirection_undo_list` is then disposed (not
+applied) because the parent is not exec'ing; only the regular
+`redirection_undo_list` is replayed.
+
+If any redirections fail, the fast-spawn path undoes whatever it managed
+to apply and declines the fast-spawn, leaving the caller to fall back to
+`make_child()`.
+
+Two further follow-ups remain. An unwind-protect frame around the
+parent-redirection window would ensure that an interrupt or trap
+during `do_redirections()` cannot leave the parent with
+half-applied redirections, corrupted undo-list globals, or a
+permanently blocked signal mask. Lifting the fd >= 3 restriction
+requires walking the new undo list and setting `FD_CLOEXEC` on each
+save fd before `spawnve()`. Heredoc support requires careful
+attention to temp-file cleanup on crash; the happy path is already
+correct.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 153 +++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 145 insertions(+), 8 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 18b53f4..5321259 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6461,6 +6461,78 @@ do_piping (int pipe_in, int pipe_out)
+ }
+ 
+ #ifdef __CYGWIN__
++/* Decide whether a single redirect can safely be applied in the parent
++   process before spawnve() and undone afterwards.  See the long comment
++   on fast_spawn_redirect_supported below for the criteria. */
++static int
++fast_spawn_redirect_one_supported (REDIRECT *r)
++{
++  /* Variable-assignment redirects ({var}<file) bind a shell variable;
++     in the regular path that mutation happens in the post-fork child
++     and disappears with it.  We must not perform that mutation in the
++     parent. */
++  if (r->rflags & REDIR_VARASSIGN)
++    return 0;
++
++  /* Limit to file descriptors 0, 1 and 2.  add_undo_redirect() can leave
++     the parent-side save fd open across exec for higher fds, which would
++     leak into the spawned child.  Forcing close-on-exec on all save fds
++     before spawnve would close that gap, but is more invasive than this
++     initial cut warrants. */
++  if (r->redirector.dest < 0 || r->redirector.dest > 2)
++    return 0;
++
++  switch (r->instruction)
++    {
++    case r_input_direction:		/* <file */
++    case r_output_direction:		/* >file */
++    case r_appending_to:		/* >>file */
++    case r_input_output:		/* <>file */
++    case r_output_force:		/* >|file (noclobber bypass) */
++    case r_err_and_out:			/* &>file */
++    case r_append_err_and_out:		/* &>>file */
++      /* Filename redirections.  Detect process substitution (`<(cmd)`,
++	 `>(cmd)`) and bail; redirection_expand() would spawn the
++	 substitution children as children of the main shell rather than
++	 of the (would-be) forked external command, with substantial
++	 follow-on bookkeeping. */
++      if (r->redirectee.filename
++	  && r->redirectee.filename->word
++	  && (strncmp (r->redirectee.filename->word, "<(", 2) == 0
++	      || strncmp (r->redirectee.filename->word, ">(", 2) == 0))
++	return 0;
++      return 1;
++
++    case r_duplicating_input:		/* <&N (constant fd) */
++    case r_duplicating_output:		/* >&N (constant fd) */
++    case r_close_this:			/* <&-, >&- */
++      /* Constant-fd dup or close.  No expansion, no substitution, no
++	 mutation of parent state beyond fd-table changes that the undo
++	 list will reverse. */
++      return 1;
++
++    default:
++      /* Heredocs, here-strings, word-form fd duplications and the
++	 various move-fd instructions are intentionally excluded.  They
++	 either spawn helpers, allocate temp files, or perform word
++	 expansion that can have side effects. */
++      return 0;
++    }
++}
++
++/* Walk the redirect list and accept it only if every entry passes the
++   per-entry test above.  Returns non-zero if the whole list can be
++   handled in the parent by the fast path. */
++static int
++fast_spawn_redirect_supported (REDIRECT *list)
++{
++  REDIRECT *r;
++  for (r = list; r; r = r->next)
++    if (!fast_spawn_redirect_one_supported (r))
++      return 0;
++  return 1;
++}
++
+ /* Spawnve-based fast path for synchronous external commands on
+    MSYS2/Cygwin.  Uses `spawnve(...)`, which lowers to `CreateProcess(...)`
+    directly on Windows; that is roughly twice as fast as
+@@ -6471,11 +6543,21 @@ do_piping (int pipe_in, int pipe_out)
+    On success returns the pid of the new child, already registered with
+    the job table so the caller's normal `wait_for(last_made_pid)` path
+    reaps it.  Returns `FAST_SPAWN_DECLINE` if the command cannot be
+-   handled by the fast path (pipes, redirections, async, `CMD_NO_FORK`,
+-   `fds_to_close`, or `shopt -s nofastspawn`), in which case the
+-   caller must fall back to `make_child(...)`.  Subsequent commits
+-   extend the fast path to cover more cases (redirections, pipelines,
+-   heredocs, async, ...). */
++   handled by the fast path (pipes, async, `CMD_NO_FORK`,
++   `fds_to_close`, redirections that fail the safety checks, or
++   `shopt -s nofastspawn`), in which case the caller must fall back
++   to `make_child(...)`.
++
++   When the redirection list is non-empty and
++   `fast_spawn_redirect_supported(...)` accepts it, the redirections
++   are applied in the parent (with `RX_UNDOABLE`) before `spawnve(...)`
++   and the inverse ops are replayed afterwards to restore the parent's
++   fd table.  Both `redirection_undo_list` and
++   `exec_redirection_undo_list` are protocol-managed: saved on entry,
++   set to `NULL` across `do_redirections(...)` (so the caller's
++   existing pending undos are not disposed), captured on success, and
++   restored.  Subsequent commits extend the fast path to cover more
++   cases (pipelines, heredocs, async, ...). */
+ static pid_t
+ fast_spawn_command (char *command, WORD_LIST *words,
+ 		    REDIRECT *redirects, char *command_line,
+@@ -6486,6 +6568,11 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   pid_t pid;
+   sigset_t set, oset;
+   int fork_flags;
++  REDIRECT *saved_undo_list = NULL;
++  REDIRECT *saved_exec_undo_list = NULL;
++  REDIRECT *new_undo_list = NULL;
++  REDIRECT *new_exec_undo_list = NULL;
++  int redirected = 0;
+ 
+   /* Runtime escape hatch: when `shopt -s nofastspawn' is in effect,
+      always decline so the caller falls through to the regular
+@@ -6497,12 +6584,12 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   /* Conditions we don't yet handle.  Bail out and let make_child do it. */
+   if (pipe_in != NO_PIPE || pipe_out != NO_PIPE)
+     return FAST_SPAWN_DECLINE;
+-  if (redirects)
+-    return FAST_SPAWN_DECLINE;
+   if (async)
+     return FAST_SPAWN_DECLINE;
+   if (cmdflags & CMD_NO_FORK)
+     return FAST_SPAWN_DECLINE;
++  if (redirects && !fast_spawn_redirect_supported (redirects))
++    return FAST_SPAWN_DECLINE;
+ 
+   /* If there are inherited pipe fds that the child must not see,
+      fall back; the regular path closes them in the child after fork. */
+@@ -6516,7 +6603,9 @@ fast_spawn_command (char *command, WORD_LIST *words,
+ 
+   /* Mirror make_child's signal blocking around the spawn so that SIGCHLD
+      for the new child is held until we have registered it in the job
+-     table.  Otherwise waitchld() could fire before add_process(). */
++     table.  Otherwise waitchld() could fire before add_process().  We
++     also block before applying redirections so that an ill-timed signal
++     can't leave the parent's fds half-rewritten if we have to bail. */
+   sigemptyset (&set);
+   sigaddset (&set, SIGCHLD);
+   sigaddset (&set, SIGINT);
+@@ -6524,6 +6613,43 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   sigemptyset (&oset);
+   sigprocmask (SIG_BLOCK, &set, &oset);
+ 
++  /* Apply redirections in the parent.  The regular path does this in
++     the post-fork child where the fork has given it a private fd table;
++     we don't have that luxury, so we ask do_redirections for the undo
++     ops and replay them after spawnve to restore our fds.  We swap
++     both redirection_undo_list and exec_redirection_undo_list out for
++     private storage so any pre-existing pending undos owned by the
++     caller are preserved (do_redirections disposes of any list in
++     these globals at entry under RX_UNDOABLE). */
++  if (redirects)
++    {
++      saved_undo_list = redirection_undo_list;
++      saved_exec_undo_list = exec_redirection_undo_list;
++      redirection_undo_list = (REDIRECT *)NULL;
++      exec_redirection_undo_list = (REDIRECT *)NULL;
++
++      if (do_redirections (redirects, RX_ACTIVE | RX_UNDOABLE) != 0)
++	{
++	  /* Redirection failed; do_redirections has already printed an
++	     error and recorded inverse ops for whatever it managed to
++	     apply.  Roll those back, restore the caller's undo lists,
++	     unblock signals, and fall back to the fork path so the
++	     child fails the same way under the existing machinery. */
++	  cleanup_redirects (redirection_undo_list);
++	  dispose_redirects (exec_redirection_undo_list);
++	  redirection_undo_list = saved_undo_list;
++	  exec_redirection_undo_list = saved_exec_undo_list;
++	  sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
++	  return FAST_SPAWN_DECLINE;
++	}
++
++      new_undo_list = redirection_undo_list;
++      new_exec_undo_list = exec_redirection_undo_list;
++      redirection_undo_list = saved_undo_list;
++      exec_redirection_undo_list = saved_exec_undo_list;
++      redirected = 1;
++    }
++
+   making_children ();
+ 
+   args = strvec_from_word_list (words, 1, 0, (int *)NULL);
+@@ -6533,6 +6659,17 @@ fast_spawn_command (char *command, WORD_LIST *words,
+ 
+   strvec_dispose (args);
+ 
++  /* Restore the parent's fd table now that the child (which inherited
++     the redirected fds) is launched.  The exec-undo entries we built
++     are no longer needed; dispose them rather than apply them, since
++     they only matter when the parent is going to exec() (i.e. the
++     `exec >file' builtin path), which is not our case. */
++  if (redirected)
++    {
++      cleanup_redirects (new_undo_list);
++      dispose_redirects (new_exec_undo_list);
++    }
++
+   if (pid < 0)
+     {
+       /* spawnve failed; restore signals and fall back to fork+exec. */
+-- 
+2.54.0.windows.1
+

--- a/bash/0016-execute_cmd-handle-pipeline-stages-in-the-spawnve-fa.patch
+++ b/bash/0016-execute_cmd-handle-pipeline-stages-in-the-spawnve-fa.patch
@@ -1,0 +1,265 @@
+From 14ec9f04879c674186e0d2be4e18afa099b78092 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 18:06:56 +0200
+Subject: [PATCH 16/N] execute_cmd: handle pipeline stages in the spawnve fast
+ path
+
+Extend the fast-spawn path to accept `pipe_in`, `pipe_out` and
+`fds_to_close`, which previously caused an unconditional bail-out.  The
+fork path applies these in the post-fork child via `do_piping()` and
+`close_fd_bitmap()`; the fast-spawn path has no such hook, so it
+emulates the same effect in the parent before `spawnve()` and reverses
+it afterwards.
+
+File descriptors that need to be temporarily overridden are duplicated
+with `FD_CLOEXEC` to avoid them leaking into the spawned child process,
+and restored in reverse order after the spawn.
+
+Microbenchmark results (200 iterations, warm averages, versus the
+unpatched Bash):
+
+  workload                            distro    patched
+  ----------------------------------- -------   --------
+  /usr/bin/true                       7.7s      4.0s    (1.93x)
+  /usr/bin/true >/dev/null 2>&1       7.7s      4.0s    (1.93x)
+  /usr/bin/true | /usr/bin/cat       13.7s     15.2s    (0.90x)
+  t1022-read-tree-partial-clone.sh    4.9s      2.4s    (2.05x)
+
+The 2-stage-pipeline microbench is at parity with unpatched Bash, but
+slightly slower (~10%); each pipeline stage now does extra parent-side
+fd surgery (`dup()`, `fcntl()`, `dup2()` setup and restore) that the
+fork path got for free in the post-fork child. Real Git tests like t1022
+still see a 2.05x speedup overall because they are dominated by plain
+externals and redirected externals where the fast path's spawnve-vs-fork
+advantage is large.
+
+This change also tightens the redirection filter to bail out on filename
+redirections containing command substitution (`$(cmd)` or backticks).
+Without that filter, a redirect like `>"$(VAR=foo cmd)"` would have
+`redirection_expand()` run the substitution in the parent shell, leaking
+variable assignments and trap effects that the fork path would have
+isolated to the child. Plain parameter expansion (`>"$VAR"`,
+`>"${VAR}"`) and tilde expansion remain accepted; they are pure reads of
+shell state.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 149 +++++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 122 insertions(+), 27 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 5321259..48918e8 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6491,16 +6491,23 @@ fast_spawn_redirect_one_supported (REDIRECT *r)
+     case r_output_force:		/* >|file (noclobber bypass) */
+     case r_err_and_out:			/* &>file */
+     case r_append_err_and_out:		/* &>>file */
+-      /* Filename redirections.  Detect process substitution (`<(cmd)`,
+-	 `>(cmd)`) and bail; redirection_expand() would spawn the
+-	 substitution children as children of the main shell rather than
+-	 of the (would-be) forked external command, with substantial
+-	 follow-on bookkeeping. */
+-      if (r->redirectee.filename
+-	  && r->redirectee.filename->word
+-	  && (strncmp (r->redirectee.filename->word, "<(", 2) == 0
+-	      || strncmp (r->redirectee.filename->word, ">(", 2) == 0))
+-	return 0;
++      /* Filename redirections.  redirection_expand performs full word
++	 expansion (parameter, command, process substitution).  Process
++	 substitution and command substitution would run in our parent
++	 shell rather than in the (would-be) forked external command,
++	 turning child-side effects into parent-side effects.  Detect
++	 the common dangerous prefixes by literal scan.  Plain
++	 parameter expansion (`>$VAR`, `>"${VAR}"`) and tilde expansion
++	 are fine because they are pure, side-effect-free reads of
++	 shell state. */
++      if (r->redirectee.filename && r->redirectee.filename->word)
++	{
++	  const char *w = r->redirectee.filename->word;
++	  if (strncmp (w, "<(", 2) == 0 || strncmp (w, ">(", 2) == 0)
++	    return 0;	/* process substitution */
++	  if (strstr (w, "$(") != NULL || strchr (w, '`') != NULL)
++	    return 0;	/* command substitution */
++	}
+       return 1;
+ 
+     case r_duplicating_input:		/* <&N (constant fd) */
+@@ -6573,6 +6580,9 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   REDIRECT *new_undo_list = NULL;
+   REDIRECT *new_exec_undo_list = NULL;
+   int redirected = 0;
++  int saved_fd0 = -1, saved_fd1 = -1;
++  int *saved_cloexec = NULL;
++  int i;
+ 
+   /* Runtime escape hatch: when `shopt -s nofastspawn' is in effect,
+      always decline so the caller falls through to the regular
+@@ -6582,8 +6592,6 @@ fast_spawn_command (char *command, WORD_LIST *words,
+     return FAST_SPAWN_DECLINE;
+ 
+   /* Conditions we don't yet handle.  Bail out and let make_child do it. */
+-  if (pipe_in != NO_PIPE || pipe_out != NO_PIPE)
+-    return FAST_SPAWN_DECLINE;
+   if (async)
+     return FAST_SPAWN_DECLINE;
+   if (cmdflags & CMD_NO_FORK)
+@@ -6591,16 +6599,6 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   if (redirects && !fast_spawn_redirect_supported (redirects))
+     return FAST_SPAWN_DECLINE;
+ 
+-  /* If there are inherited pipe fds that the child must not see,
+-     fall back; the regular path closes them in the child after fork. */
+-  if (fds_to_close)
+-    {
+-      int i;
+-      for (i = 0; i < fds_to_close->size; i++)
+-	if (fds_to_close->bitmap[i])
+-	  return FAST_SPAWN_DECLINE;
+-    }
+-
+   /* Mirror make_child's signal blocking around the spawn so that SIGCHLD
+      for the new child is held until we have registered it in the job
+      table.  Otherwise waitchld() could fire before add_process().  We
+@@ -6613,7 +6611,52 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   sigemptyset (&oset);
+   sigprocmask (SIG_BLOCK, &set, &oset);
+ 
+-  /* Apply redirections in the parent.  The regular path does this in
++  /* Set up pipe_in -> fd 0 and pipe_out -> fd 1 in the parent.  We
++     keep the originals as save fds (with FD_CLOEXEC so spawnve does
++     not leak them to the child) for restoration after spawnve.  The
++     pipeline coordinator in execute_pipeline owns pipe_in / pipe_out
++     and will close them once we return; we do not close them here. */
++  if (pipe_in != NO_PIPE)
++    {
++      saved_fd0 = dup (0);
++      if (saved_fd0 < 0
++	  || fcntl (saved_fd0, F_SETFD, FD_CLOEXEC) < 0
++	  || dup2 (pipe_in, 0) < 0)
++	goto pipe_setup_fail;
++    }
++  if (pipe_out != NO_PIPE)
++    {
++      saved_fd1 = dup (1);
++      if (saved_fd1 < 0
++	  || fcntl (saved_fd1, F_SETFD, FD_CLOEXEC) < 0
++	  || dup2 (pipe_out, 1) < 0)
++	goto pipe_setup_fail;
++    }
++
++  /* fds_to_close holds pipe ends inherited from neighboring pipeline
++     stages that the child must not see.  In the regular path the
++     post-fork child closes them via close_fd_bitmap(); spawnve gives
++     us no such hook, so we set FD_CLOEXEC on each listed fd before
++     the spawn and restore the previous flag bits after. */
++  if (fds_to_close && fds_to_close->size > 0)
++    {
++      saved_cloexec = (int *)xmalloc (fds_to_close->size * sizeof (int));
++      for (i = 0; i < fds_to_close->size; i++)
++	{
++	  saved_cloexec[i] = -1;
++	  if (fds_to_close->bitmap[i])
++	    {
++	      int flags = fcntl (i, F_GETFD);
++	      if (flags >= 0)
++		{
++		  saved_cloexec[i] = flags;
++		  fcntl (i, F_SETFD, flags | FD_CLOEXEC);
++		}
++	    }
++	}
++    }
++
++  /* Apply user redirections.  The regular path does this in the
+      the post-fork child where the fork has given it a private fd table;
+      we don't have that luxury, so we ask do_redirections for the undo
+      ops and replay them after spawnve to restore our fds.  We swap
+@@ -6633,14 +6676,14 @@ fast_spawn_command (char *command, WORD_LIST *words,
+ 	  /* Redirection failed; do_redirections has already printed an
+ 	     error and recorded inverse ops for whatever it managed to
+ 	     apply.  Roll those back, restore the caller's undo lists,
+-	     unblock signals, and fall back to the fork path so the
+-	     child fails the same way under the existing machinery. */
++	     restore pipes/cloexec, unblock signals, and fall back to
++	     the fork path so the child fails the same way under the
++	     existing machinery. */
+ 	  cleanup_redirects (redirection_undo_list);
+ 	  dispose_redirects (exec_redirection_undo_list);
+ 	  redirection_undo_list = saved_undo_list;
+ 	  exec_redirection_undo_list = saved_exec_undo_list;
+-	  sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
+-	  return FAST_SPAWN_DECLINE;
++	  goto pipe_setup_fail;
+ 	}
+ 
+       new_undo_list = redirection_undo_list;
+@@ -6670,6 +6713,32 @@ fast_spawn_command (char *command, WORD_LIST *words,
+       dispose_redirects (new_exec_undo_list);
+     }
+ 
++  /* Restore FD_CLOEXEC on neighboring-pipe-stage fds. */
++  if (saved_cloexec)
++    {
++      for (i = 0; i < fds_to_close->size; i++)
++	if (saved_cloexec[i] >= 0)
++	  fcntl (i, F_SETFD, saved_cloexec[i]);
++      free (saved_cloexec);
++      saved_cloexec = NULL;
++    }
++
++  /* Restore fd 1, then fd 0.  Restoration order is the reverse of
++     setup order so that if pipe_in == 1 (fd 1 used as a pipe input)
++     the dup2 chain stays correct. */
++  if (saved_fd1 >= 0)
++    {
++      dup2 (saved_fd1, 1);
++      close (saved_fd1);
++      saved_fd1 = -1;
++    }
++  if (saved_fd0 >= 0)
++    {
++      dup2 (saved_fd0, 0);
++      close (saved_fd0);
++      saved_fd0 = -1;
++    }
++
+   if (pid < 0)
+     {
+       /* spawnve failed; restore signals and fall back to fork+exec. */
+@@ -6686,5 +6755,31 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
+ 
+   return pid;
++
++pipe_setup_fail:
++  /* Restore everything we set up.  The order matches the cleanup path
++     above: restore CLOEXEC on neighboring fds, then restore fd 1,
++     then fd 0, then unblock signals.  saved_fd0/saved_fd1 may be -1
++     if the corresponding setup never ran or never finished; close()
++     and dup2() on -1 are skipped explicitly. */
++  if (saved_cloexec)
++    {
++      for (i = 0; i < fds_to_close->size; i++)
++	if (saved_cloexec[i] >= 0)
++	  fcntl (i, F_SETFD, saved_cloexec[i]);
++      free (saved_cloexec);
++    }
++  if (saved_fd1 >= 0)
++    {
++      dup2 (saved_fd1, 1);
++      close (saved_fd1);
++    }
++  if (saved_fd0 >= 0)
++    {
++      dup2 (saved_fd0, 0);
++      close (saved_fd0);
++    }
++  sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
++  return FAST_SPAWN_DECLINE;
+ }
+ #endif /* __CYGWIN__ */
+-- 
+2.54.0.windows.1
+

--- a/bash/0017-execute_cmd-factor-out-shared-expand-resolve-helpers.patch
+++ b/bash/0017-execute_cmd-factor-out-shared-expand-resolve-helpers.patch
@@ -1,0 +1,136 @@
+From 17b9475cc39505df00747b087ca994dd5dcef93d Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 21:08:00 +0200
+Subject: [PATCH 17/N] execute_cmd: factor out shared expand/resolve helpers
+
+The fast-spawn path will need to perform parent-side word expansion and
+`PATH` resolution, just like `execute_simple_command()`. To avoid
+duplication, let's refactor the functionality into two helper functions.
+
+Microbenchmark variance check: 7-run medians on 200x `/usr/bin/true |
+/usr/bin/cat` are 7.04s before this refactor and 7.12s after, a ~1%
+delta well within run-to-run noise. Git's own test script
+`t1022-read-tree-partial-clone.sh` runs at the same ~2.4s warm average,
+i.e. no regression.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 80 ++++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 57 insertions(+), 23 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 48918e8..349699f 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -532,6 +532,60 @@ shell_control_structure (enum command_type type)
+     }
+ }
+ 
++/* Expand a simple command's words, mirroring the pre/post setup the
++   slow path in execute_simple_command does around its expand_words
++   call.  Used by both the slow path and the spawnve fast path so the
++   two cannot drift if upstream changes the expansion contract. */
++static WORD_LIST *
++expand_simple_command_words (SIMPLE_COM *simple_command, int cmdflags,
++			     struct fd_bitmap *fds_to_close)
++{
++  WORD_LIST *words;
++
++  /* If we are re-running this as the result of executing the `command'
++     builtin, do not expand the command words a second time. */
++  if (cmdflags & CMD_INHIBIT_EXPANSION)
++    return copy_word_list (simple_command->words);
++
++  current_fds_to_close = fds_to_close;
++  fix_assignment_words (simple_command->words);
++#if defined (ARRAY_VARS)
++  fix_arrayref_words (simple_command->words);
++#endif
++  /* Pass the ignore return flag down to command substitutions */
++  if (cmdflags & CMD_IGNORE_RETURN)	/* XXX */
++    comsub_ignore_return++;
++  words = expand_words (simple_command->words);
++  if (cmdflags & CMD_IGNORE_RETURN)
++    comsub_ignore_return--;
++  current_fds_to_close = (struct fd_bitmap *)NULL;
++
++  return words;
++}
++
++/* Resolve the executable for a simple command via PATH (with bash's
++   hash cache for repeats) and update the export environment so the
++   spawned program can find its own name in $_.  Used by both
++   execute_disk_command and the spawnve fast path so the two cannot
++   drift on path-search semantics or the env-update side effects.
++   Returns a freshly-allocated path the caller must free, or NULL if
++   the command was not found. */
++static char *
++resolve_simple_command_path (const char *pathname, int cmdflags)
++{
++  int stdpath = (cmdflags & CMD_STDPATH);
++  char *command;
++
++  command = search_for_command (pathname,
++				CMDSRCH_HASH | (stdpath ? CMDSRCH_STDPATH : 0));
++  if (command)
++    {
++      maybe_make_export_env ();
++      put_command_name_into_env (command);
++    }
++  return command;
++}
++
+ /* A function to use to unwind_protect the redirection undo list
+    for loops. */
+ static void
+@@ -4633,25 +4687,8 @@ execute_simple_command (SIMPLE_COM *simple_command, int pipe_in, int pipe_out, i
+ 
+   QUIT;		/* XXX */
+ 
+-  /* If we are re-running this as the result of executing the `command'
+-     builtin, do not expand the command words a second time. */
+-  if ((cmdflags & CMD_INHIBIT_EXPANSION) == 0)
+-    {
+-      current_fds_to_close = fds_to_close;
+-      fix_assignment_words (simple_command->words);
+-#if defined (ARRAY_VARS)
+-      fix_arrayref_words (simple_command->words);
+-#endif
+-      /* Pass the ignore return flag down to command substitutions */
+-      if (cmdflags & CMD_IGNORE_RETURN)	/* XXX */
+-	comsub_ignore_return++;
+-      words = expand_words (simple_command->words);
+-      if (cmdflags & CMD_IGNORE_RETURN)
+-	comsub_ignore_return--;
+-      current_fds_to_close = (struct fd_bitmap *)NULL;
+-    }
+-  else
+-    words = copy_word_list (simple_command->words);
++  words = expand_simple_command_words (simple_command, cmdflags,
++				       fds_to_close);
+ 
+   /* It is possible for WORDS not to have anything left in it.
+      Perhaps all the words consisted of `$foo', and there was
+@@ -5836,7 +5873,7 @@ execute_disk_command (WORD_LIST *words, REDIRECT *redirects, char *command_line,
+      any pathname it finds into the hash table, it should read
+      command = search_for_command (pathname, stdpath ? CMDSRCH_STDPATH : CMDSRCH_HASH);
+   */
+-  command = search_for_command (pathname, CMDSRCH_HASH|(stdpath ? CMDSRCH_STDPATH : 0));
++  command = resolve_simple_command_path (pathname, cmdflags);
+   QUIT;
+ 
+   if (command)
+@@ -5846,9 +5883,6 @@ execute_disk_command (WORD_LIST *words, REDIRECT *redirects, char *command_line,
+ 	 in a pipeline environment, assuming it's already been done. */
+       if (nofork && pipe_in == NO_PIPE && pipe_out == NO_PIPE && (subshell_environment & SUBSHELL_PIPE) == 0)
+ 	adjust_shell_level (-1);
+-
+-      maybe_make_export_env ();
+-      put_command_name_into_env (command);
+     }
+   else if (command == 0 && notfound_str == 0)	/* make sure */
+     init_notfound_str ();
+-- 
+2.54.0.windows.1
+

--- a/bash/0018-execute_cmd-bypass-the-early-fork-in-pipeline-stages.patch
+++ b/bash/0018-execute_cmd-bypass-the-early-fork-in-pipeline-stages.patch
@@ -1,0 +1,258 @@
+From 86ef3cf3395c3451b2c921026dc6e1f8597bddc8 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 19:25:42 +0200
+Subject: [PATCH 18/N] execute_cmd: bypass the early fork in pipeline stages
+
+The function `execute_simple_command()` forks early for any command with
+a pipe or async marker. By the time the fast-spawn path could kick in,
+it is too late.
+
+Fix that. When the conditions are right, do word expansion, builtin /
+function detection and `PATH` resolution in the parent, and hand the
+resolved external straight to `fast_spawn_command()`, which spawns it
+via `spawnve()` with the pipe fds already wired up. No fork happens at
+any point; the parent goes directly from "we have a pipeline stage" to
+"we have a registered child pid".
+
+A microbenchmark of 200 iterations of `/usr/bin/true | /usr/bin/cat`
+drops from ~13.6s (distro bash) to ~7.4s warm, about 1.83x faster than
+the unpatched Bash and matching the speedup the simple external-command
+path already enjoyed. `t/t1022-read-tree-partial-clone.sh`, which has a
+few pipelines under `do_test_run`, drops a further ~5% (2.50s to 2.39s).
+
+The new helper `try_fast_simple_spawn()` is intentionally conservative
+in what it accepts; the goal is to be safe in a single audit pass rather
+than to maximize coverage in this first cut. The eligibility criteria
+are as follows. Only synchronous pipeline stages qualify; async stages
+route through different bookkeeping in `execute_simple_command()`
+(`subshell_environment`, `last_asynchronous_pid`) that the fast path
+does not yet replicate. The command must have no `W_ASSIGNMENT` words
+anywhere in `simple_command->words`: the whole point of the early fork
+is to keep `VAR=val cmd` from setting `VAR` in the parent shell, so
+expansion in the parent has to refuse cases where expansion would mutate
+parent state. None of `${`, `$(` or backtick may appear anywhere in the
+literal words: plain `$VAR` is a pure read of shell state and is
+observably identical whether evaluated in parent or child; `${VAR:=...}`
+can assign and `$(...)` or backticks run arbitrary commands with
+arbitrary side effects, all of which would be "in the parent instead of
+in the child" on the fast path. Redirections must still pass
+`fast_spawn_redirect_supported()`. The resolved first word may not be a
+shell builtin (regular, special or assignment) and may not be a shell
+function; both must run in-process and cannot be spawned. This last
+check is done after expansion via `find_special_builtin()`,
+`find_shell_builtin()` and `find_function()` on the now-resolved name.
+
+Trade-offs explicitly considered. Word expansion in the parent versus
+the child: eligibility above guarantees no observable difference, since
+there is no command substitution, no parameter expansion with
+assignment, and no `W_ASSIGNMENT` side effects; plain `$VAR`, `${VAR}`,
+`${VAR/foo/bar}`, glob and tilde expansions are all pure reads of shell
+state. `search_for_command()` in the parent versus the child walks
+`PATH` (with hash-cache shortcut for repeats) and `stat()`s the
+candidate; no mutation of shell state, and the cost is amortized across
+iterations because the hash cache survives between calls.
+`put_command_name_into_env()` and `maybe_make_export_env()` update `_`
+in the environment and may regenerate `export_env`; the regular path
+does the same in `execute_disk_command()`, so doing them earlier in the
+parent is safe and avoids a redundant re-evaluation. On error paths, if
+`fast_spawn_command()` fails (`spawnve()` returned -1, or a redirect
+failure inside the helper bailed out), the code path falls back to
+forking a child process; the forked child re-does the redirections and
+fails there with the same error message, so the diagnostic may appear
+once or twice depending on which step failed.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 149 +++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 147 insertions(+), 2 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 349699f..d4a5c8a 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -201,6 +201,8 @@ static int execute_disk_command (WORD_LIST *, REDIRECT *, char *,
+ static pid_t fast_spawn_command (char *, WORD_LIST *, REDIRECT *,
+ 				 char *, int, int, int,
+ 				 struct fd_bitmap *, int);
++static pid_t try_fast_simple_spawn (SIMPLE_COM *, int, int, int,
++				    struct fd_bitmap *, int);
+ #endif
+ 
+ static char *getinterp (char *, int, int *);
+@@ -4620,6 +4622,29 @@ execute_simple_command (SIMPLE_COM *simple_command, int pipe_in, int pipe_out, i
+ 	(simple_command->words->word->word[0] == '%'))
+     dofork = 0;
+ 
++#ifdef __CYGWIN__
++  /* Try the spawnve fast path before paying for the early fork.  If
++     the helper accepts the command it has already spawned the child
++     and registered it in the job table; we just need to do the
++     parent-side cleanup that the regular fork path does after
++     make_child returns the parent pid (close pipe ends, leave $?
++     alone for non-final pipeline stages, return).  See
++     try_fast_simple_spawn for the eligibility criteria. */
++  if (dofork)
++    {
++      pid_t fast_pid = try_fast_simple_spawn (simple_command, pipe_in,
++					      pipe_out, async, fds_to_close,
++					      cmdflags);
++      if (fast_pid >= 0)
++	{
++	  if (pipe_out != NO_PIPE)
++	    result = last_command_exit_value;
++	  close_pipes (pipe_in, pipe_out);
++	  return (result);
++	}
++    }
++#endif /* __CYGWIN__ */
++
+   if (dofork)
+     {
+       char *p, *xc;
+@@ -6597,8 +6622,17 @@ fast_spawn_redirect_supported (REDIRECT *list)
+    `exec_redirection_undo_list` are protocol-managed: saved on entry,
+    set to `NULL` across `do_redirections(...)` (so the caller's
+    existing pending undos are not disposed), captured on success, and
+-   restored.  Subsequent commits extend the fast path to cover more
+-   cases (pipelines, heredocs, async, ...). */
++   restored.
++
++   For pipeline stages, `pipe_in` and `pipe_out` are dup'd into fd 0
++   and fd 1 in the parent (saving the originals so they can be
++   restored) and the `fds_to_close` bitmap (extra pipe ends from
++   neighboring stages) is given `FD_CLOEXEC` so `spawnve(...)`'s child
++   does not inherit those fds.  The regular fork path achieves the
++   same effect in the post-fork child via `do_piping(...)` and
++   `close_fd_bitmap(...)`; the fast path has to do it here in the
++   parent because `spawnve(...)` does not give a "between fork and
++   exec" hook to run code in the child. */
+ static pid_t
+ fast_spawn_command (char *command, WORD_LIST *words,
+ 		    REDIRECT *redirects, char *command_line,
+@@ -6630,6 +6664,12 @@ fast_spawn_command (char *command, WORD_LIST *words,
+     return FAST_SPAWN_DECLINE;
+   if (cmdflags & CMD_NO_FORK)
+     return FAST_SPAWN_DECLINE;
++  if (pipe_out == REDIRECT_BOTH)
++    /* `cmd |& next' merges stderr into the pipe.  do_piping handles
++       this by dup2(1, 2) AFTER the rest of the pipe redirection has
++       happened; we'd need to interleave that into our pipe setup
++       below.  Defer to a follow-up.  */
++    return FAST_SPAWN_DECLINE;
+   if (redirects && !fast_spawn_redirect_supported (redirects))
+     return FAST_SPAWN_DECLINE;
+ 
+@@ -6816,4 +6856,109 @@ pipe_setup_fail:
+   sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
+   return FAST_SPAWN_DECLINE;
+ }
++
++/* Bypass the early fork in execute_simple_command for pipeline /
++   async stages whose command is unambiguously an external program
++   we can hand straight to spawnve.  Returns the pid of the spawned
++   child on success, or (pid_t)-1 if the fast path declined and the
++   caller should fall back to the regular fork path.
++
++   This is the upstream half of the spawnve fast path: the dispatcher
++   in execute_disk_command already shortcuts plain external commands,
++   but execute_simple_command forks before that for any pipe stage,
++   making the dispatcher unreachable in pipelines.  Here we attempt
++   to take the same shortcut earlier, so a pipeline like `cmd | other'
++   never has to pay the fork() cost in the parent.
++
++   Eligibility (intentionally conservative for an initial cut):
++     - synchronous (async commands have a different bookkeeping regime
++       in execute_simple_command);
++     - no W_ASSIGNMENT words (would mutate parent shell state);
++     - no `${', `$(' or backticks anywhere in the literal words
++       (parameter-expansion-with-side-effects, command substitution,
++       command substitution, all of which would run in the parent
++       rather than in the child);
++     - redirections pass fast_spawn_redirect_supported;
++     - the resolved first word is not a shell builtin or function. */
++static pid_t
++try_fast_simple_spawn (SIMPLE_COM *simple_command,
++		       int pipe_in, int pipe_out, int async,
++		       struct fd_bitmap *fds_to_close, int cmdflags)
++{
++  WORD_LIST *w, *expanded;
++  char *path = NULL;
++  char *command_line = NULL;
++  pid_t pid;
++
++  if (async)
++    return (pid_t)-1;
++
++  for (w = simple_command->words; w; w = w->next)
++    {
++      const char *s;
++
++      if (w->word->flags & W_ASSIGNMENT)
++	return (pid_t)-1;
++
++      s = w->word->word;
++      if (s == NULL)
++	return (pid_t)-1;
++
++      if (strstr (s, "${") || strstr (s, "$(") || strchr (s, '`'))
++	return (pid_t)-1;
++    }
++
++  if (simple_command->redirects
++      && !fast_spawn_redirect_supported (simple_command->redirects))
++    return (pid_t)-1;
++
++  /* Word expansion in the parent.  Eligibility above guarantees no
++     command substitution, no command substitution, and no parameter
++     expansion with assignment side effects, so this is observably
++     equivalent to expanding in the post-fork child. */
++  expanded = expand_simple_command_words (simple_command, cmdflags,
++					  fds_to_close);
++
++  if (expanded == NULL || expanded->word == NULL
++      || expanded->word->word == NULL || expanded->word->word[0] == '\0')
++    {
++      dispose_words (expanded);
++      return (pid_t)-1;
++    }
++
++  /* If the first word names a shell builtin or function we cannot
++     spawn it; bail out and let the regular path run it in-process
++     (after forking, since dofork is true). */
++  if (find_special_builtin (expanded->word->word)
++      || find_shell_builtin (expanded->word->word)
++      || find_function (expanded->word->word))
++    {
++      dispose_words (expanded);
++      return (pid_t)-1;
++    }
++
++  path = resolve_simple_command_path (expanded->word->word, cmdflags);
++  if (path == NULL)
++    {
++      dispose_words (expanded);
++      return (pid_t)-1;
++    }
++
++  command_line = savestring (the_printed_command_except_trap
++			      ? the_printed_command_except_trap : "");
++
++  pid = fast_spawn_command (path, expanded, simple_command->redirects,
++			    command_line, pipe_in, pipe_out, async,
++			    fds_to_close, cmdflags);
++
++  /* fast_spawn_command's register_spawned_child copies command_line
++     via savestring, so our local copy can go.  Likewise the resolved
++     path: spawnve only used it to look up the executable, it owns no
++     reference to the string. */
++  free (command_line);
++  free (path);
++  dispose_words (expanded);
++
++  return pid;
++}
+ #endif /* __CYGWIN__ */
+-- 
+2.54.0.windows.1
+

--- a/bash/0019-execute_cmd-support-no-expansion-heredocs-in-the-fas.patch
+++ b/bash/0019-execute_cmd-support-no-expansion-heredocs-in-the-fas.patch
@@ -1,0 +1,89 @@
+From 85f643d154921cfa3aef01ccd816323428380471 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 6 May 2026 22:55:29 +0200
+Subject: [PATCH 19/N] execute_cmd: support no-expansion heredocs in the
+ fast-spawn path
+
+Extend the fast-spawn path to accept `r_reading_until` and
+`r_deblank_reading_until` (the `<<EOF` and `<<-EOF` instructions) when
+the redirectee word has `W_QUOTED` set.  `W_QUOTED` is the parser's
+record that the heredoc delimiter was quoted (`<<\EOF`, `<<'EOF'`,
+`<<"EOF"`, ...) and means `heredoc_expand(...)` will return the body
+verbatim instead of running it through `expand_string_to_string(...)`
+with `Q_HERE_DOCUMENT`.  Without `W_QUOTED`, expansion would run any
+`$(cmd)` inside the heredoc body in the parent shell rather than in the
+spawned child, which is the same parent-side-effects hazard that makes
+the fast path bail on filename redirections containing command
+substitution.
+
+For the `W_QUOTED` subset, `here_document_to_fd(...)` just writes the
+literal body to a temp file (unlinked at creation) and returns its read
+fd. `do_redirection_internal(...)` then `dup2(...)`s the redirector onto
+it under the existing `RX_UNDOABLE` bookkeeping, so
+`cleanup_redirects(...)` after `spawnve(...)` restores the parent fd
+table normally and the spawned child inherits the read fd via
+`spawnve(...)`'s standard fd-table inheritance.
+
+Heredocs are pervasive in Git's test suite under `t/*.sh`, with roughly
+half using the no-expansion form. Microbenchmark wins (200 iterations,
+warm averages, versus the distro bash):
+
+  workload                          distro    patched   speedup
+  --------------------------------- --------  --------  -------
+  cat <<\EOF .. EOF >/dev/null      7.17s     3.32s     2.16x
+  heredoc | sort >/dev/null         12.57s    7.50s     1.68x
+
+Plain-pipeline and t1022 numbers do not change here; t1022 does not
+use heredocs in its hot path so it does not benefit.
+
+Two cases remain out of scope. Expanding heredocs (`<<EOF` without
+quoting) would require walking the body for `$(`, backticks and
+`${VAR:=...}`-style assignment-on-default to detect that expansion has
+no observable side effects; possible but more invasive than this cut.
+`r_reading_string` (`<<<word`) is also deferred: `heredoc_expand(...)`
+always expands here-strings regardless of `W_QUOTED`, so the same
+parent-side-effects hazard applies and the fast path would have to
+inspect the word for substitution markers similarly to filename
+redirections.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index d4a5c8a..a64806c 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6577,6 +6577,27 @@ fast_spawn_redirect_one_supported (REDIRECT *r)
+ 	 list will reverse. */
+       return 1;
+ 
++    case r_reading_until:		/* <<EOF */
++    case r_deblank_reading_until:	/* <<-EOF */
++      /* Heredocs.  Allow only the no-expansion variants `<<\EOF' and
++	 `<<\'EOF\'', identified by W_QUOTED on the redirectee word.
++	 Without W_QUOTED, the body undergoes parameter / command /
++	 arithmetic expansion in heredoc_expand(), which would run any
++	 `$(cmd)' inside the body in our parent shell rather than in the
++	 spawned child.  When W_QUOTED is set the body is taken
++	 literally and here_document_to_fd just writes it to a temp file
++	 -- safe to do in the parent.
++	 here_document_to_fd creates a temp file (unlinked at creation
++	 so it does not survive a crash visibly), writes the body, and
++	 returns its read-only fd; do_redirection_internal then dup2s
++	 redirector onto it under RX_UNDOABLE bookkeeping, so
++	 cleanup_redirects after spawnve restores parent's fd table
++	 normally and the child inherits the read fd. */
++      if (r->redirectee.filename
++	  && (r->redirectee.filename->flags & W_QUOTED))
++	return 1;
++      return 0;
++
+     default:
+       /* Heredocs, here-strings, word-form fd duplications and the
+ 	 various move-fd instructions are intentionally excluded.  They
+-- 
+2.54.0.windows.1
+

--- a/bash/0020-execute_cmd-extract-a-reusable-scanner-for-unsafe-wo.patch
+++ b/bash/0020-execute_cmd-extract-a-reusable-scanner-for-unsafe-wo.patch
@@ -1,0 +1,170 @@
+From ebf37f0cfef550144ef55aacbd6097ab19fc18ca Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 8 May 2026 10:51:43 -0700
+Subject: [PATCH 20/N] execute_cmd: extract a reusable scanner for unsafe word
+ expansion
+
+The fast path filters out words whose expansion could have observable
+parent-side effects: command substitution, backtick command
+substitution, and the `${VAR:=...}` / `${VAR:?...}` parameter- expansion
+operators that mutate or abort. The check is needed in three places: the
+filename-redirect filter, the simple-command-words eligibility scan, and
+the upcoming heredoc-body check. Maintaining three inlined near-copies
+is a drift hazard.
+
+Extract a single helper, `fast_spawn_word_has_unsafe_expansion(...)`,
+that all three call sites use. Beyond removing the duplication, the
+helper also tightens the criteria in two ways that are observable
+behavior changes worth flagging.
+
+First, it tracks `${...}` nesting depth, so `:=` and `:?` are flagged
+only when they actually act as parameter-expansion operators. A literal
+`cmd key:=value` or `path:?fallback` in a command argument is no longer
+rejected. Second, it accepts the side-effect-free `${...}` operators
+(`${VAR}`, `${VAR:-default}`, `${VAR:+alt}`, `${VAR%suffix}`,
+`${VAR#prefix}`, `${VAR/foo/bar}`, etc.) which would otherwise be
+rejected by the bare presence of `${`.
+
+Backslash is honored as a one-pass two-character skip, which correctly
+handles `\$(literal)` and `\${VAR}` in unquoted text, double-quoted
+text, and heredoc bodies.
+
+Single-quote state is intentionally not tracked. The same scanner will
+be applied to heredoc bodies in a follow-up commit, where `'` is a
+literal apostrophe, not the start of a quoted region; treating it as a
+quote region would be unsafe in heredoc bodies (`'$(rm -rf /)'` inside a
+heredoc body really does substitute). The trade-off favors safety: the
+resulting false positives on words like `'$(literal)'` (single-quoted in
+an argument) cost some fast-path coverage but never accept anything that
+would run arbitrary commands in the parent.
+
+Microbenchmark: a workload exercising `:=` outside parameter expansion
+(200 iterations of `/usr/bin/echo "x:=y" | /usr/bin/cat`) drops from
+~12s on the distro bash to ~7s warm.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 87 ++++++++++++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 76 insertions(+), 11 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index a64806c..55fa97f 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6520,6 +6520,71 @@ do_piping (int pipe_in, int pipe_out)
+ }
+ 
+ #ifdef __CYGWIN__
++/* True if expanding STR in the parent shell could have observable
++   side effects beyond pure reads of shell state.  STR may be a word
++   from a simple-command argument list, a redirect filename, or a
++   heredoc body.  We flag four constructs:
++
++     - command substitution `$(' or `` ` ''  -- runs commands;
++     - assignment-on-default `:=' inside `${...}'  -- sets the
++       referenced variable when unset;
++     - error-on-default     `:?' inside `${...}'  -- aborts with
++       a diagnostic when the referenced variable is unset.
++
++   Backslash is honored as a one-pass two-character skip, which
++   correctly handles `\$(literal)' and `\${VAR}' in unquoted text,
++   double-quoted text and (for the substitution operators we care
++   about) heredoc bodies.
++
++   The scan tracks `${...}' nesting depth so that `:=' and `:?' are
++   only flagged when they actually act as parameter-expansion
++   operators, not when they are literal text in a command argument
++   like `cmd key:=value'.  A plain `}' outside any `${...}' is
++   treated as a literal character; a `${' inside another `${...}'
++   nests.
++
++   No false negatives in any context: anything we let through is
++   provably side-effect-free in the parent shell.  Quote state is
++   intentionally not tracked: it would be unsafe in heredoc bodies,
++   where `'' is a literal apostrophe and not the start of a quoted
++   region. */
++static int
++fast_spawn_word_has_unsafe_expansion (const char *s)
++{
++  int depth = 0;
++
++  if (s == NULL)
++    return 0;
++
++  for (; *s; s++)
++    {
++      if (*s == '\\' && s[1])
++	{
++	  s++;	/* loop increment skips the escaped char */
++	  continue;
++	}
++      if (*s == '`')
++	return 1;
++      if (s[0] == '$' && s[1] == '(')
++	return 1;
++      if (s[0] == '$' && s[1] == '{')
++	{
++	  depth++;
++	  s++;
++	  continue;
++	}
++      if (*s == '}' && depth > 0)
++	{
++	  depth--;
++	  continue;
++	}
++      if (depth > 0 && s[0] == ':' && (s[1] == '=' || s[1] == '?'))
++	return 1;
++    }
++
++  return 0;
++}
++
+ /* Decide whether a single redirect can safely be applied in the parent
+    process before spawnve() and undone afterwards.  See the long comment
+    on fast_spawn_redirect_supported below for the criteria. */
+@@ -6551,21 +6616,21 @@ fast_spawn_redirect_one_supported (REDIRECT *r)
+     case r_err_and_out:			/* &>file */
+     case r_append_err_and_out:		/* &>>file */
+       /* Filename redirections.  redirection_expand performs full word
+-	 expansion (parameter, command, process substitution).  Process
+-	 substitution and command substitution would run in our parent
+-	 shell rather than in the (would-be) forked external command,
+-	 turning child-side effects into parent-side effects.  Detect
+-	 the common dangerous prefixes by literal scan.  Plain
+-	 parameter expansion (`>$VAR`, `>"${VAR}"`) and tilde expansion
+-	 are fine because they are pure, side-effect-free reads of
+-	 shell state. */
++	 expansion (parameter, command, process substitution).  We
++	 accept the redirect only if the filename word's expansion is
++	 side-effect-free (parameter expansion or tilde expansion only,
++	 no command/process substitution, no assignment-on-default).
++	 See fast_spawn_word_has_unsafe_expansion for the criteria;
++	 process substitution is detected here via its leading `<('
++	 or `>(' since fast_spawn_word_has_unsafe_expansion only
++	 detects `$(' / backtick (command substitution). */
+       if (r->redirectee.filename && r->redirectee.filename->word)
+ 	{
+ 	  const char *w = r->redirectee.filename->word;
+ 	  if (strncmp (w, "<(", 2) == 0 || strncmp (w, ">(", 2) == 0)
+ 	    return 0;	/* process substitution */
+-	  if (strstr (w, "$(") != NULL || strchr (w, '`') != NULL)
+-	    return 0;	/* command substitution */
++	  if (fast_spawn_word_has_unsafe_expansion (w))
++	    return 0;
+ 	}
+       return 1;
+ 
+@@ -6925,7 +6990,7 @@ try_fast_simple_spawn (SIMPLE_COM *simple_command,
+       if (s == NULL)
+ 	return (pid_t)-1;
+ 
+-      if (strstr (s, "${") || strstr (s, "$(") || strchr (s, '`'))
++      if (fast_spawn_word_has_unsafe_expansion (s))
+ 	return (pid_t)-1;
+     }
+ 
+-- 
+2.54.0.windows.1
+

--- a/bash/0021-execute_cmd-support-expanding-heredocs-whose-body-is.patch
+++ b/bash/0021-execute_cmd-support-expanding-heredocs-whose-body-is.patch
@@ -1,0 +1,97 @@
+From a23a368115c65e986f71e796992c809dcf19805a Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sat, 9 May 2026 12:21:44 +0200
+Subject: [PATCH 21/N] execute_cmd: support expanding heredocs whose body is
+ safe
+
+The fast path accepts the no-expansion heredoc forms (`<<\EOF`,
+`<<'EOF'`), where `heredoc_expand(...)` short-circuits and returns the
+body verbatim. Roughly half of Git's heredoc usages under `t/*.sh` are
+of the expanding form (`<<EOF`, `<<-EOF`), typically interpolating
+`$VAR` into expected-output fixtures or test setup. Extend the fast path
+to accept those too, when the body is provably side-effect-free.
+
+`fast_spawn_word_has_unsafe_expansion(...)` already classifies word
+expansion as safe or unsafe by the same criteria. Apply the same scanner
+to the heredoc body: if it contains nothing worse than plain `$VAR`,
+`${VAR}` or read-only `${...}` operators, heredoc expansion in the
+parent is observably equivalent to expansion in the post-fork child. The
+body cannot mutate parent shell state or run arbitrary commands, so it
+is safe to feed through the existing `RX_UNDOABLE` temp-file path the
+same way `W_QUOTED` bodies are.
+
+`$(cmd)`, backticks and `${VAR:=...}` / `${VAR:?...}` anywhere in the
+body still cause a fall-back to the fork path, because those would have
+observable effects in the parent shell.
+
+A 200-iteration microbenchmark of an expanding-heredoc workload drops
+from ~7.0s on the unpatched Bash to ~3.1s warm, the same ~2.2x speedup
+the no-expansion heredoc form already enjoyed. t1022 is unchanged
+because it does not exercise heredocs in its hot path.
+
+Here-strings (`<<<word`) remain out of scope here.
+`heredoc_expand(...)` always expands here-strings via
+`expand_assignment_string_to_string(...)`, regardless of `W_QUOTED`.
+The same scanner check applies in principle, but here-strings are rare
+in test scripts and are deferred to a follow-up.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 37 +++++++++++++++++++++++--------------
+ 1 file changed, 23 insertions(+), 14 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 55fa97f..7f391c9 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6644,23 +6644,32 @@ fast_spawn_redirect_one_supported (REDIRECT *r)
+ 
+     case r_reading_until:		/* <<EOF */
+     case r_deblank_reading_until:	/* <<-EOF */
+-      /* Heredocs.  Allow only the no-expansion variants `<<\EOF' and
+-	 `<<\'EOF\'', identified by W_QUOTED on the redirectee word.
+-	 Without W_QUOTED, the body undergoes parameter / command /
+-	 arithmetic expansion in heredoc_expand(), which would run any
+-	 `$(cmd)' inside the body in our parent shell rather than in the
+-	 spawned child.  When W_QUOTED is set the body is taken
+-	 literally and here_document_to_fd just writes it to a temp file
+-	 -- safe to do in the parent.
+-	 here_document_to_fd creates a temp file (unlinked at creation
+-	 so it does not survive a crash visibly), writes the body, and
+-	 returns its read-only fd; do_redirection_internal then dup2s
+-	 redirector onto it under RX_UNDOABLE bookkeeping, so
+-	 cleanup_redirects after spawnve restores parent's fd table
+-	 normally and the child inherits the read fd. */
++      /* Heredocs.  Two cases are accepted:
++
++	 1. The no-expansion form (`<<\EOF', `<<\'EOF\''), identified
++	    by W_QUOTED on the redirectee word.  heredoc_expand
++	    short-circuits and returns the body verbatim, so no
++	    expansion happens at all -- the body's contents do not
++	    matter.
++
++	 2. The expanding form, but only when the body's expansion
++	    is side-effect-free per fast_spawn_word_has_unsafe_expansion
++	    (no command substitution, no `${VAR:=...}', no `${VAR:?...}'
++	    in the body).  Same criterion as filename redirections.
++
++	 here_document_to_fd creates a temp file (unlinked at
++	 creation), writes the (possibly-expanded) body, and returns
++	 its read fd; do_redirection_internal dup2s redirector onto
++	 it under RX_UNDOABLE bookkeeping, so cleanup_redirects after
++	 spawnve restores the parent fd table normally and the child
++	 inherits the read fd. */
+       if (r->redirectee.filename
+ 	  && (r->redirectee.filename->flags & W_QUOTED))
+ 	return 1;
++      if (r->redirectee.filename
++	  && r->redirectee.filename->word
++	  && !fast_spawn_word_has_unsafe_expansion (r->redirectee.filename->word))
++	return 1;
+       return 0;
+ 
+     default:
+-- 
+2.54.0.windows.1
+

--- a/bash/0022-execute_cmd-support-here-strings-word-in-the-spawnve.patch
+++ b/bash/0022-execute_cmd-support-here-strings-word-in-the-spawnve.patch
@@ -1,0 +1,68 @@
+From efc0431768008fbca4fced4ff25308d43a71782f Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 11 May 2026 17:00:35 +0200
+Subject: [PATCH 22/N] execute_cmd: support here-strings (`<<<word`) in the
+ spawnve fast path
+
+Add `r_reading_string` to the redirection filter alongside the heredoc
+cases. `here_document_to_fd()` handles `<<<word` by expanding the word
+via `expand_assignment_string_to_string()` and writing the result plus a
+trailing newline to a temp file; `do_redirection_internal()` then wires
+it up under `RX_UNDOABLE` the same way it does for true heredocs.
+
+The eligibility check is the same as for the expanding heredoc case:
+accept if `fast_spawn_word_has_unsafe_expansion()` returns false on the
+word, i.e. no command substitution, no backticks, no `${VAR:=...}` and
+no `${VAR:?...}`. Plain `$VAR`, `${VAR}`, `${VAR%foo}` and friends are
+fine. `W_QUOTED` on the redirectee is intentionally not honored here:
+`heredoc_expand()` short-circuits `W_QUOTED` only for true heredocs (the
+`if (ri != r_reading_string && ...)` branch at `redir.c:362`), so for
+here-strings expansion always happens at execution time and the body
+content is what must be checked.
+
+No new code path; just one more case in the switch.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 7f391c9..a0bc764 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6672,11 +6672,26 @@ fast_spawn_redirect_one_supported (REDIRECT *r)
+ 	return 1;
+       return 0;
+ 
++    case r_reading_string:		/* <<<word */
++      /* Here-strings.  heredoc_expand calls
++	 expand_assignment_string_to_string which performs parameter,
++	 command and arithmetic expansion regardless of W_QUOTED.
++	 Accept only when the word's expansion is side-effect-free per
++	 the same scanner used everywhere else.  here_document_to_fd
++	 writes the expanded string plus a trailing newline to a temp
++	 file just like for true heredocs; do_redirection_internal
++	 wires it up under RX_UNDOABLE. */
++      if (r->redirectee.filename
++	  && r->redirectee.filename->word
++	  && !fast_spawn_word_has_unsafe_expansion (r->redirectee.filename->word))
++	return 1;
++      return 0;
++
+     default:
+-      /* Heredocs, here-strings, word-form fd duplications and the
+-	 various move-fd instructions are intentionally excluded.  They
+-	 either spawn helpers, allocate temp files, or perform word
+-	 expansion that can have side effects. */
++      /* Word-form fd duplications and the various move-fd
++	 instructions are intentionally excluded.  They either spawn
++	 helpers, allocate temp files, or perform word expansion that
++	 can have side effects. */
+       return 0;
+     }
+ }
+-- 
+2.54.0.windows.1
+

--- a/bash/0023-execute_cmd-support-async-commands-in-the-spawnve-fa.patch
+++ b/bash/0023-execute_cmd-support-async-commands-in-the-spawnve-fa.patch
@@ -1,0 +1,80 @@
+From a81d65d64b4dcae97061a37ebb41487684252442 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sun, 10 May 2026 11:56:46 +0200
+Subject: [PATCH 23/N] execute_cmd: support async commands in the spawnve fast
+ path
+
+Drop the two async bail-outs: `spawnve(_P_NOWAIT, ...)` returns
+immediately without waiting for the child, which is exactly what async
+semantics require, and `register_spawned_child()` already handles
+`FORK_ASYNC` by setting `last_asynchronous_pid` (so `$!` works). No new
+code path is needed; the fast path only has to stop refusing.
+
+Microbenchmark wins (200 iterations, warm average, versus the
+unpatched Bash):
+
+  workload                                  distro    patched   speedup
+  ----------------------------------------- --------  --------  -------
+  /usr/bin/true & wait $!                   7.96s     3.13s     2.54x
+  /usr/bin/true | /usr/bin/cat & wait $!    11.68s    6.92s     1.69x
+
+Two gaps remain out of scope. `setup_async_signals()` makes the
+post-fork child ignore `SIGINT` and `SIGQUIT` so an interactive Ctrl-C
+does not kill background jobs in the fork path that runs after `fork()`
+in the child, but `spawnve()` has no such hook and Cygwin's `spawnve()`
+does not accept a sigmask attribute. For non-interactive Bash (test
+scripts and the Git test suite generally) this does not matter: `SIGINT`
+is not delivered to begin with. An interactive shell that backgrounds a
+command which then needs to survive Ctrl-C would observe a behavior
+change. `async_redirect_stdin()` redirects fd 0 to `/dev/null` when the
+async command has no explicit stdin redirect and `CMD_STDIN_REDIR` is
+set; this prevents async commands from stealing the parent's stdin in
+interactive shells. Test scripts do not exercise this.
+
+Both gaps are addressable. The stdin redirect can be done as one more
+parent-side `dup2()` and restore around `spawnve()`, similarly
+to pipeline fd surgery, and the `SIGINT`-ignore could be approximated
+by wrapping `spawnve()` with a temporary signal mask. Both are
+deferred.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index a0bc764..925b2e4 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6770,8 +6770,6 @@ fast_spawn_command (char *command, WORD_LIST *words,
+     return FAST_SPAWN_DECLINE;
+ 
+   /* Conditions we don't yet handle.  Bail out and let make_child do it. */
+-  if (async)
+-    return FAST_SPAWN_DECLINE;
+   if (cmdflags & CMD_NO_FORK)
+     return FAST_SPAWN_DECLINE;
+   if (pipe_out == REDIRECT_BOTH)
+@@ -6981,8 +6979,6 @@ pipe_setup_fail:
+    never has to pay the fork() cost in the parent.
+ 
+    Eligibility (intentionally conservative for an initial cut):
+-     - synchronous (async commands have a different bookkeeping regime
+-       in execute_simple_command);
+      - no W_ASSIGNMENT words (would mutate parent shell state);
+      - no `${', `$(' or backticks anywhere in the literal words
+        (parameter-expansion-with-side-effects, command substitution,
+@@ -7000,9 +6996,6 @@ try_fast_simple_spawn (SIMPLE_COM *simple_command,
+   char *command_line = NULL;
+   pid_t pid;
+ 
+-  if (async)
+-    return (pid_t)-1;
+-
+   for (w = simple_command->words; w; w = w->next)
+     {
+       const char *s;
+-- 
+2.54.0.windows.1
+

--- a/bash/0024-execute_cmd-remove-dead-REDIRECT_BOTH-bail-out-from-.patch
+++ b/bash/0024-execute_cmd-remove-dead-REDIRECT_BOTH-bail-out-from-.patch
@@ -1,0 +1,69 @@
+From dd76c611477c0881c8ebf5a7ec93dff3205a5b81 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 11 May 2026 17:52:56 +0200
+Subject: [PATCH 24/N] execute_cmd: remove dead REDIRECT_BOTH bail-out from
+ fast path
+
+The `if (pipe_out == REDIRECT_BOTH) return FAST_SPAWN_DECLINE` guard in
+`fast_spawn_command()` is unreachable. The parser at `parse.y:1473-1481`
+rewrites `cmd1 |& cmd2` as `cmd1 2>&1 | cmd2` at parse time:
+
+        |       pipeline BAR_AND newline_list pipeline
+                        {
+                          /* Make cmd1 |& cmd2 equivalent to cmd1 2>&1 | cmd2 */
+                          COMMAND *tc;
+                          ...
+                        }
+
+So by the time `execute_pipeline()` runs, the AST has a plain `|`
+connector with an extra `r_err_and_out` redirect on the left command.
+The fast path handles that pipeline form already; the extra `2>&1` is
+a regular `r_duplicating_output` redirect which the redirection filter
+accepts. Remove the guard.
+
+`REDIRECT_BOTH` (the constant value `-2` in `shell.h`) is still
+referenced by `do_piping()` in case it is invoked elsewhere with
+`REDIRECT_BOTH` as `pipe_out` (coprocess plumbing, for instance), but it
+is no longer an exclusion on the fast path.
+
+Verified manually:
+
+  $ sh -c 'echo out; echo err >&2' |& sort
+  err
+  out
+
+  $ sh -c 'echo out; echo err >&2' 2>&1 | sort
+  err
+  out
+
+Both forms take the fast path and produce identical output. The
+function's doc comment is updated at the same time to reflect the
+current bail-out conditions (the `async` and `REDIRECT_BOTH` entries no
+longer apply).
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 925b2e4..28d2a18 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6772,12 +6772,6 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   /* Conditions we don't yet handle.  Bail out and let make_child do it. */
+   if (cmdflags & CMD_NO_FORK)
+     return FAST_SPAWN_DECLINE;
+-  if (pipe_out == REDIRECT_BOTH)
+-    /* `cmd |& next' merges stderr into the pipe.  do_piping handles
+-       this by dup2(1, 2) AFTER the rest of the pipe redirection has
+-       happened; we'd need to interleave that into our pipe setup
+-       below.  Defer to a follow-up.  */
+-    return FAST_SPAWN_DECLINE;
+   if (redirects && !fast_spawn_redirect_supported (redirects))
+     return FAST_SPAWN_DECLINE;
+ 
+-- 
+2.54.0.windows.1
+

--- a/bash/0025-execute_cmd-lift-fd-3-redirect-restriction-in-the-sp.patch
+++ b/bash/0025-execute_cmd-lift-fd-3-redirect-restriction-in-the-sp.patch
@@ -1,0 +1,117 @@
+From e96a81bd5659ba793e8e99de31876d27ebc4eebc Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 11 May 2026 20:56:16 +0200
+Subject: [PATCH 25/N] execute_cmd: lift fd >= 3 redirect restriction in the
+ spawnve fast path
+
+The redirection filter rejects any redirect whose redirector fd is >= 3,
+citing that `add_undo_redirect()` in `redir.c` does not force
+close-on-exec on the parent-side save fd when the original fd was
+open-on-exec. Without that guarantee, the save fd would be inherited by
+the `spawnve()` child as some high-numbered fd, exactly the kind of
+pipeline-stage fd leak the rest of the fast path works hard to avoid.
+
+Lift the restriction by walking the new undo list after
+`do_redirections()` succeeds and forcing `FD_CLOEXEC` on each save fd
+explicitly. Each undo entry built by `add_undo_redirect()` is a chained
+pair: an `r_duplicating_input` or `r_duplicating_output` to dup the save
+fd back over the original, followed by an `r_close_this` to close the
+save fd. The save fd is the redirectee of the duplicating entry, so a
+single linked-list traversal that picks out `r_duplicating_input` and
+`r_duplicating_output` entries finds them all.
+
+After `spawnve()`, `cleanup_redirects()` runs the undo list as a normal
+sequence of redirections: `dup2()` from the save fd back over the
+original fd, which POSIX requires clears `FD_CLOEXEC` on the target. So
+the forced `FD_CLOEXEC` on the save fd does not leak into the restored
+original. Re-marking save fds that were already `FD_CLOEXEC` (the fd < 3
+case, or fd >= 3 with `O_CLOEXEC` already set) is a no-op.
+
+Test:
+
+  $ exec 3>/tmp/parent.fd3        # parent has fd 3 open
+  $ sh -c 'ls /proc/self/fd' 3>/tmp/child.fd3
+    0 -> /dev/cons0
+    1 -> pipe:[...]
+    2 -> /dev/null
+    3 -> /tmp/child.fd3            # the user's redirect
+    4 -> /proc/.../fd              # ls's own opendir
+                                   # no leaked save fd
+  $ echo "still here" >&3          # parent fd 3 still open
+
+The "still here" text reaches `/tmp/parent.fd3` as expected, so
+`cleanup_redirects()` restored the parent's fd 3 correctly.
+
+This change covers redirections on the user-visible redirect list.  Pipe
+save fds (`saved_fd0` / `saved_fd1`) created by `fast_spawn_command()`'s
+own setup are already explicitly marked `FD_CLOEXEC` via `fcntl(F_SETFD,
+FD_CLOEXEC)` at `dup()` time, and the `fds_to_close` bitmap entries are
+restored to their original `FD_CLOEXEC` state by the existing
+save/restore pass.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 39 +++++++++++++++++++++++++++++++++------
+ 1 file changed, 33 insertions(+), 6 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 28d2a18..0e8cd9b 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6598,12 +6598,10 @@ fast_spawn_redirect_one_supported (REDIRECT *r)
+   if (r->rflags & REDIR_VARASSIGN)
+     return 0;
+ 
+-  /* Limit to file descriptors 0, 1 and 2.  add_undo_redirect() can leave
+-     the parent-side save fd open across exec for higher fds, which would
+-     leak into the spawned child.  Forcing close-on-exec on all save fds
+-     before spawnve would close that gap, but is more invasive than this
+-     initial cut warrants. */
+-  if (r->redirector.dest < 0 || r->redirector.dest > 2)
++  /* A negative redirector is the parser's record of an out-of-range
++     file descriptor; let make_child reject it the same way it always
++     has. */
++  if (r->redirector.dest < 0)
+     return 0;
+ 
+   switch (r->instruction)
+@@ -6867,6 +6865,35 @@ fast_spawn_command (char *command, WORD_LIST *words,
+       redirection_undo_list = saved_undo_list;
+       exec_redirection_undo_list = saved_exec_undo_list;
+       redirected = 1;
++
++      /* Force FD_CLOEXEC on each save fd in the undo list before the
++	 spawnve.  add_undo_redirect() in redir.c only sets close-on-
++	 exec on save fds when the original fd was < 3 or had
++	 close-on-exec set; for higher fds whose original was
++	 open-on-exec, the save fd is left open-on-exec too and would
++	 otherwise be inherited by the spawnve child.  Without this
++	 walk, `cmd 3>foo' would let the spawned child see the save
++	 copy of the original fd 3 at some high-numbered slot.
++
++	 Each undo entry is a chained pair (r_duplicating_input or
++	 r_duplicating_output to restore, then r_close_this to close
++	 the save fd).  The save fd is the redirectee in the
++	 duplicating entries.  cleanup_redirects after spawnve runs
++	 dup2 from save fd back to the original, which clears the
++	 CLOEXEC bit on the target as POSIX requires, so our forced
++	 CLOEXEC on save fds does not affect the restored original. */
++      {
++	REDIRECT *u;
++	for (u = new_undo_list; u; u = u->next)
++	  if (u->instruction == r_duplicating_input
++	      || u->instruction == r_duplicating_output)
++	    {
++	      int sfd = u->redirectee.dest;
++	      int flags;
++	      if (sfd >= 0 && (flags = fcntl (sfd, F_GETFD)) >= 0)
++		fcntl (sfd, F_SETFD, flags | FD_CLOEXEC);
++	    }
++      }
+     }
+ 
+   making_children ();
+-- 
+2.54.0.windows.1
+

--- a/bash/0026-execute_cmd-skip-fast-spawn-path-when-unable-to-repl.patch
+++ b/bash/0026-execute_cmd-skip-fast-spawn-path-when-unable-to-repl.patch
@@ -1,0 +1,98 @@
+From 475bad401b5a4a1af22aa086867c25521911cad1 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Mon, 11 May 2026 21:02:38 +0200
+Subject: [PATCH 26/N] execute_cmd: skip fast-spawn path when unable to
+ replicate child-side setup
+
+The spawnve fast path has no between-fork-and-exec window where
+child-side setup code can run. Two categories of such setup exist in the
+regular fork+exec path that the fast path cannot replicate.
+
+For background commands in interactive shells, the post-fork child runs
+`setup_async_signals(...)` to make the background job ignore `SIGINT`
+and `SIGQUIT` (so Ctrl-C does not kill it), and
+`async_redirect_stdin(...)` to redirect fd 0 from `/dev/null` (so the
+background job does not steal the terminal's input).
+`setup_async_signals(...)` could be approximated by wrapping
+`spawnve(...)` with temporary `SIG_IGN` in the parent, but that opens a
+window where signals delivered to the parent are silently lost.
+`async_redirect_stdin(...)` could be approximated with a save /
+`dup2(...)` / restore around fd 0, but it changes parent behavior in
+subtle ways. Both deserve their own follow-up commits.
+
+For foreground commands under job control, the post-fork child runs
+`setpgid(mypid, pipeline_pgrp)` and `give_terminal_to(pipeline_pgrp, 0)`
+(`jobs.c:2390`, `:2400`).  `register_spawned_child(...)` attempts the
+`setpgid(...)` from the parent side after `spawnve(...)` has already
+returned, but this races with the child's cygwin process-record
+initialization: the child's `getpgid(0)` reports the new pgid while
+`kill(-pgid, ...)` against the same id returns `ESRCH`, because cygwin's
+pgrp-by-id index has not been updated atomically. Any spawned program
+that calls `initialize_job_control(...)` (another `bash -i`, the shell
+tmux places in window 0, etc.) then loops 16 times on `kill(0, SIGTTIN)`
+getting `ESRCH` and falls back to "no job control in background",
+leaving the child unable to manage its terminal. The structurally
+correct fix is `posix_spawn(...)` with `POSIX_SPAWN_SETPGROUP`, which
+sets the child's pgid atomically as part of the spawn syscall, but
+msys2-runtime does not yet expose a usable `posix_spawn(...)`.
+
+Bail out of the fast path for both cases: when `async &&
+interactive_shell`, and when `!async && job_control`.  Non-interactive
+shells (the Git for Windows test suite path) have `job_control == 0` and
+do not background commands interactively, so they keep the fast path
+with the full 2x+ speedup. The only commands that lose the fast path are
+those typed at an interactive prompt, where the per-command fork
+overhead is in the low-millisecond range and imperceptible against the
+actual work the command does.
+
+Assisted-by: Opus 4.6
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 0e8cd9b..b32c7f6 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6770,6 +6770,37 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   /* Conditions we don't yet handle.  Bail out and let make_child do it. */
+   if (cmdflags & CMD_NO_FORK)
+     return FAST_SPAWN_DECLINE;
++  if (async && interactive_shell)
++    /* In interactive shells, the regular fork path runs
++       setup_async_signals() in the post-fork child to make the
++       background job ignore SIGINT and SIGQUIT, and (when
++       CMD_STDIN_REDIR is set and stdin is not explicitly redirected)
++       redirects stdin to /dev/null so the background job does not
++       compete for the terminal's input.  Cygwin's spawnve gives us
++       no between-fork-and-exec hook to replicate either effect.  In
++       non-interactive shells (the test-suite path) those effects do
++       not matter, so we keep the fast path enabled there. */
++    return FAST_SPAWN_DECLINE;
++  if (!async && job_control)
++    /* For foreground commands the regular fork path's child runs
++       setpgid(mypid, pipeline_pgrp) and, when the new pgrp differs
++       from shell_pgrp, give_terminal_to(pipeline_pgrp, 0) between
++       fork and exec (jobs.c:2390, 2400).  register_spawned_child's
++       parent-side setpgid races with the child's cygwin process
++       record initialization: when the child reaches the spawned
++       program's main() before the parent's setpgid has fully
++       updated the cygwin pgrp index, getpgid() reports the new
++       pgid but kill(-pgid, ...) returns ESRCH against it, breaking
++       any spawned program that runs initialize_job_control (bash
++       -i, tmux's default-shell window, etc.).  No spawn-side fix
++       inside this fast path can close that race without a child-
++       side hook; the structurally correct fix is posix_spawn with
++       POSIX_SPAWN_SETPGROUP, which sets the child's pgid atomically
++       as part of the spawn syscall, but msys2-runtime does not yet
++       expose a usable posix_spawn.  Until then, bail out for this
++       case.  Non-interactive shells have job_control == 0 and stay
++       on the fast path; the GfW test suite is unaffected. */
++    return FAST_SPAWN_DECLINE;
+   if (redirects && !fast_spawn_redirect_supported (redirects))
+     return FAST_SPAWN_DECLINE;
+ 
+-- 
+2.54.0.windows.1
+

--- a/bash/0027-execute_cmd-wrap-the-spawnve-fast-path-in-an-unwind-.patch
+++ b/bash/0027-execute_cmd-wrap-the-spawnve-fast-path-in-an-unwind-.patch
@@ -1,0 +1,404 @@
+From 64194b934f2c5b7d0228a853f3c0703b72244b33 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 2 Jun 2026 14:24:45 +0200
+Subject: [PATCH 27/N] execute_cmd: wrap the spawnve fast path in an
+ unwind-protect frame
+
+Upon problems, the fast-spawn path rolls back its parent-side mutations
+(signal mask, fd 0 / fd 1 dups, `FD_CLOEXEC` bits on the `fds_to_close`
+bitmap, and the global redirection list swaps) via two near-duplicated
+cleanup blocks: one for the success branch and one reached via `goto
+pipe_setup_fail`. That covers the failures the code already knows to
+handle (redirection setup errors, `spawnve()` returning -1) but leaves
+no backstop for any `longjmp()` through the critical section.  In
+practice `do_redirections()` and the `xmalloc()` for `saved_cloexec` can
+both `longjmp()` to `top_level` (fatal trap, OOM, an interrupt that
+retriggers the `EXIT` trap, etc.); on that path the parent would be left
+with fd 0 or fd 1 pointing at a pipe end, `redirection_undo_list`
+containing partial undos owned by the spawn that never completed, and
+signals still blocked.
+
+Move all five mutations under a single function and call
+`run_unwind_frame()` at every exit point: success, `do_redirections()`
+failure, `spawnve()` failure, and the early `dup()` / `dup2()` /
+`fcntl()` bail-outs. Three small static callbacks plus a wrapper for
+`sigprocmask()` share state with the function via stack-allocated
+structs. LIFO registration order means restoration runs as redirects,
+then `FD_CLOEXEC`, then fd 1, then fd 0, then sigmask, matching the
+explicit cleanup it replaces.
+
+The `redir_save.active` flag distinguishes the window during
+`do_redirections()` (the globals still hold the partial undos) from the
+window after the new undos have been moved into locals (and so a
+callback firing then must be a no-op so the caller's undo lists are not
+double-disposed). The new undo lists are cleaned up explicitly after
+`spawnve()` since they are no longer reachable through the global slot
+the callback consults; if a `longjmp()` could occur between
+`redir_save.active = 0` and that cleanup, the lists would leak, but no
+call between those two points raises `top_level`.
+
+With the unwind frame in place the success and failure paths share one
+implementation. The `pipe_setup_fail:` label, the parallel `saved_fd0` /
+`saved_fd1` / `saved_cloexec` / `saved_undo_list` /
+`saved_exec_undo_list` locals, and the duplicated `dup2()` / `fcntl()` /
+`sigprocmask()` cleanup blocks all disappear.
+
+Assisted-by: Opus 4.7
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ execute_cmd.c | 246 +++++++++++++++++++++++++++++++-------------------
+ 1 file changed, 153 insertions(+), 93 deletions(-)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index b32c7f6..7866125 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6740,7 +6740,95 @@ fast_spawn_redirect_supported (REDIRECT *list)
+    same effect in the post-fork child via `do_piping(...)` and
+    `close_fd_bitmap(...)`; the fast path has to do it here in the
+    parent because `spawnve(...)` does not give a "between fork and
+-   exec" hook to run code in the child. */
++   exec" hook to run code in the child.
++
++   All mutations of process-wide state (signal mask, fd 0 / fd 1, the
++   FD_CLOEXEC flags on fds_to_close, and the global redirection-undo
++   lists) are guarded by a single unwind-protect frame.  If
++   xmalloc(), do_redirections(), or any other call between
++   begin_unwind_frame() and discard_unwind_frame() longjmps to
++   top_level (OOM, fatal trap, etc.), throw_to_top_level will run the
++   frame and roll each mutation back in reverse order.  On the normal
++   exit paths we run the frame explicitly to perform the same cleanup,
++   so the success and failure branches share one implementation. */
++
++/* Per-fd save state used by uw_fast_spawn_restore_fd to dup the saved
++   copy back over `target' on unwind.  Lives on the caller's stack;
++   `saved' is set to -1 by the callback after the restoration so a
++   subsequent explicit run of the frame is a no-op. */
++struct fast_spawn_fd_save
++{
++  int target;
++  int saved;
++};
++
++static void
++uw_fast_spawn_restore_fd (void *arg)
++{
++  struct fast_spawn_fd_save *s = arg;
++  if (s->saved >= 0)
++    {
++      dup2 (s->saved, s->target);
++      close (s->saved);
++      s->saved = -1;
++    }
++}
++
++/* fds_to_close-walk state.  saved[i] holds the original F_GETFD flags
++   for fd i (or -1 if that fd was not modified).  The callback restores
++   them, frees the array, and nulls it so a re-run is harmless. */
++struct fast_spawn_cloexec_save
++{
++  struct fd_bitmap *fds_to_close;
++  int *saved;
++};
++
++static void
++uw_fast_spawn_restore_cloexec (void *arg)
++{
++  struct fast_spawn_cloexec_save *s = arg;
++  int i;
++  if (s->saved == NULL)
++    return;
++  for (i = 0; i < s->fds_to_close->size; i++)
++    if (s->saved[i] >= 0)
++      fcntl (i, F_SETFD, s->saved[i]);
++  free (s->saved);
++  s->saved = NULL;
++}
++
++/* Redirection-undo-list swap state.  When `active' is non-zero the
++   global redirection_undo_list / exec_redirection_undo_list currently
++   hold partial undos owned by this function; the callback rolls them
++   back and restores the caller's saved lists.  When `active' is zero
++   (we have already moved the new undos into locals and put the caller's
++   lists back), the callback is a no-op. */
++struct fast_spawn_redir_save
++{
++  REDIRECT *saved_undo;
++  REDIRECT *saved_exec_undo;
++  int active;
++};
++
++static void
++uw_fast_spawn_restore_redirects (void *arg)
++{
++  struct fast_spawn_redir_save *s = arg;
++  if (!s->active)
++    return;
++  cleanup_redirects (redirection_undo_list);
++  dispose_redirects (exec_redirection_undo_list);
++  redirection_undo_list = s->saved_undo;
++  exec_redirection_undo_list = s->saved_exec_undo;
++  s->active = 0;
++}
++
++static void
++uw_fast_spawn_restore_sigmask (void *arg)
++{
++  sigprocmask (SIG_SETMASK, (sigset_t *)arg, (sigset_t *)NULL);
++}
++
+ static pid_t
+ fast_spawn_command (char *command, WORD_LIST *words,
+ 		    REDIRECT *redirects, char *command_line,
+@@ -6751,14 +6839,15 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   pid_t pid;
+   sigset_t set, oset;
+   int fork_flags;
+-  REDIRECT *saved_undo_list = NULL;
+-  REDIRECT *saved_exec_undo_list = NULL;
+   REDIRECT *new_undo_list = NULL;
+   REDIRECT *new_exec_undo_list = NULL;
+   int redirected = 0;
+-  int saved_fd0 = -1, saved_fd1 = -1;
+-  int *saved_cloexec = NULL;
++  struct fast_spawn_fd_save fd0_save = { 0, -1 };
++  struct fast_spawn_fd_save fd1_save = { 1, -1 };
++  struct fast_spawn_cloexec_save cloexec_save = { NULL, NULL };
++  struct fast_spawn_redir_save redir_save = { NULL, NULL, 0 };
+   int i;
++  pid_t fail_status = FAST_SPAWN_DECLINE;
+ 
+   /* Runtime escape hatch: when `shopt -s nofastspawn' is in effect,
+      always decline so the caller falls through to the regular
+@@ -6804,6 +6893,8 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   if (redirects && !fast_spawn_redirect_supported (redirects))
+     return FAST_SPAWN_DECLINE;
+ 
++  begin_unwind_frame ("fast_spawn_command");
++
+   /* Mirror make_child's signal blocking around the spawn so that SIGCHLD
+      for the new child is held until we have registered it in the job
+      table.  Otherwise waitchld() could fire before add_process().  We
+@@ -6815,6 +6906,7 @@ fast_spawn_command (char *command, WORD_LIST *words,
+   sigaddset (&set, SIGTERM);
+   sigemptyset (&oset);
+   sigprocmask (SIG_BLOCK, &set, &oset);
++  add_unwind_protect (uw_fast_spawn_restore_sigmask, &oset);
+ 
+   /* Set up pipe_in -> fd 0 and pipe_out -> fd 1 in the parent.  We
+      keep the originals as save fds (with FD_CLOEXEC so spawnve does
+@@ -6823,38 +6915,51 @@ fast_spawn_command (char *command, WORD_LIST *words,
+      and will close them once we return; we do not close them here. */
+   if (pipe_in != NO_PIPE)
+     {
+-      saved_fd0 = dup (0);
+-      if (saved_fd0 < 0
+-	  || fcntl (saved_fd0, F_SETFD, FD_CLOEXEC) < 0
++      fd0_save.saved = dup (0);
++      if (fd0_save.saved < 0
++	  || fcntl (fd0_save.saved, F_SETFD, FD_CLOEXEC) < 0
+ 	  || dup2 (pipe_in, 0) < 0)
+-	goto pipe_setup_fail;
++	{
++	  run_unwind_frame ("fast_spawn_command");
++	  return FAST_SPAWN_DECLINE;
++	}
++      add_unwind_protect (uw_fast_spawn_restore_fd, &fd0_save);
+     }
+   if (pipe_out != NO_PIPE)
+     {
+-      saved_fd1 = dup (1);
+-      if (saved_fd1 < 0
+-	  || fcntl (saved_fd1, F_SETFD, FD_CLOEXEC) < 0
++      fd1_save.saved = dup (1);
++      if (fd1_save.saved < 0
++	  || fcntl (fd1_save.saved, F_SETFD, FD_CLOEXEC) < 0
+ 	  || dup2 (pipe_out, 1) < 0)
+-	goto pipe_setup_fail;
++	{
++	  run_unwind_frame ("fast_spawn_command");
++	  return FAST_SPAWN_DECLINE;
++	}
++      add_unwind_protect (uw_fast_spawn_restore_fd, &fd1_save);
+     }
+ 
+   /* fds_to_close holds pipe ends inherited from neighboring pipeline
+      stages that the child must not see.  In the regular path the
+      post-fork child closes them via close_fd_bitmap(); spawnve gives
+      us no such hook, so we set FD_CLOEXEC on each listed fd before
+-     the spawn and restore the previous flag bits after. */
++     the spawn and restore the previous flag bits after.  We register
++     the unwind callback before populating the array so an xmalloc()
++     longjmp (impossible in practice for xmalloc, which never returns
++     NULL, but defended for clarity) leaves the structure consistent. */
+   if (fds_to_close && fds_to_close->size > 0)
+     {
+-      saved_cloexec = (int *)xmalloc (fds_to_close->size * sizeof (int));
++      cloexec_save.fds_to_close = fds_to_close;
++      cloexec_save.saved = (int *)xmalloc (fds_to_close->size * sizeof (int));
++      add_unwind_protect (uw_fast_spawn_restore_cloexec, &cloexec_save);
+       for (i = 0; i < fds_to_close->size; i++)
+ 	{
+-	  saved_cloexec[i] = -1;
++	  cloexec_save.saved[i] = -1;
+ 	  if (fds_to_close->bitmap[i])
+ 	    {
+ 	      int flags = fcntl (i, F_GETFD);
+ 	      if (flags >= 0)
+ 		{
+-		  saved_cloexec[i] = flags;
++		  cloexec_save.saved[i] = flags;
+ 		  fcntl (i, F_SETFD, flags | FD_CLOEXEC);
+ 		}
+ 	    }
+@@ -6871,30 +6976,31 @@ fast_spawn_command (char *command, WORD_LIST *words,
+      these globals at entry under RX_UNDOABLE). */
+   if (redirects)
+     {
+-      saved_undo_list = redirection_undo_list;
+-      saved_exec_undo_list = exec_redirection_undo_list;
++      redir_save.saved_undo = redirection_undo_list;
++      redir_save.saved_exec_undo = exec_redirection_undo_list;
+       redirection_undo_list = (REDIRECT *)NULL;
+       exec_redirection_undo_list = (REDIRECT *)NULL;
++      redir_save.active = 1;
++      add_unwind_protect (uw_fast_spawn_restore_redirects, &redir_save);
+ 
+       if (do_redirections (redirects, RX_ACTIVE | RX_UNDOABLE) != 0)
+ 	{
+ 	  /* Redirection failed; do_redirections has already printed an
+ 	     error and recorded inverse ops for whatever it managed to
+-	     apply.  Roll those back, restore the caller's undo lists,
+-	     restore pipes/cloexec, unblock signals, and fall back to
+-	     the fork path so the child fails the same way under the
+-	     existing machinery. */
+-	  cleanup_redirects (redirection_undo_list);
+-	  dispose_redirects (exec_redirection_undo_list);
+-	  redirection_undo_list = saved_undo_list;
+-	  exec_redirection_undo_list = saved_exec_undo_list;
+-	  goto pipe_setup_fail;
++	     apply.  Let the unwind frame roll those back (and restore
++	     pipes/cloexec/sigmask), and return FAST_SPAWN_FAILED so the
++	     caller does not retry via the fork path and duplicate the
++	     diagnostic. */
++	  fail_status = FAST_SPAWN_FAILED;
++	  run_unwind_frame ("fast_spawn_command");
++	  return fail_status;
+ 	}
+ 
+       new_undo_list = redirection_undo_list;
+       new_exec_undo_list = exec_redirection_undo_list;
+-      redirection_undo_list = saved_undo_list;
+-      exec_redirection_undo_list = saved_exec_undo_list;
++      redirection_undo_list = redir_save.saved_undo;
++      exec_redirection_undo_list = redir_save.saved_exec_undo;
++      redir_save.active = 0;
+       redirected = 1;
+ 
+       /* Force FD_CLOEXEC on each save fd in the undo list before the
+@@ -6936,85 +7042,39 @@ fast_spawn_command (char *command, WORD_LIST *words,
+ 
+   strvec_dispose (args);
+ 
+-  /* Restore the parent's fd table now that the child (which inherited
+-     the redirected fds) is launched.  The exec-undo entries we built
+-     are no longer needed; dispose them rather than apply them, since
+-     they only matter when the parent is going to exec() (i.e. the
+-     `exec >file' builtin path), which is not our case. */
++  /* Dispose of the new undo lists we captured into locals.  These are
++     not in the global slots any more so the unwind callback doesn't
++     see them; we must release them ourselves on every exit path past
++     this point.  The exec-undo entries only matter when the parent is
++     about to exec() (i.e. the `exec >file' builtin path), which is not
++     our case, so dispose rather than apply. */
+   if (redirected)
+     {
+       cleanup_redirects (new_undo_list);
+       dispose_redirects (new_exec_undo_list);
+     }
+ 
+-  /* Restore FD_CLOEXEC on neighboring-pipe-stage fds. */
+-  if (saved_cloexec)
+-    {
+-      for (i = 0; i < fds_to_close->size; i++)
+-	if (saved_cloexec[i] >= 0)
+-	  fcntl (i, F_SETFD, saved_cloexec[i]);
+-      free (saved_cloexec);
+-      saved_cloexec = NULL;
+-    }
+-
+-  /* Restore fd 1, then fd 0.  Restoration order is the reverse of
+-     setup order so that if pipe_in == 1 (fd 1 used as a pipe input)
+-     the dup2 chain stays correct. */
+-  if (saved_fd1 >= 0)
+-    {
+-      dup2 (saved_fd1, 1);
+-      close (saved_fd1);
+-      saved_fd1 = -1;
+-    }
+-  if (saved_fd0 >= 0)
+-    {
+-      dup2 (saved_fd0, 0);
+-      close (saved_fd0);
+-      saved_fd0 = -1;
+-    }
+-
+   if (pid < 0)
+     {
+-      /* spawnve failed; restore signals and fall back to fork+exec. */
+-      sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
++      /* spawnve failed; let the unwind frame restore pipes, cloexec
++	 and signal mask, then fall back to fork+exec.  (No diagnostic
++	 was printed; the fork path will report any error from the
++	 child.) */
++      run_unwind_frame ("fast_spawn_command");
+       return FAST_SPAWN_DECLINE;
+     }
+ 
+   fork_flags = async ? FORK_ASYNC : 0;
+   register_spawned_child (pid, savestring (command_line), fork_flags);
+ 
+-  /* Unblock signals now that the child is registered; a pending SIGCHLD
+-     will be delivered and waitchld() will find the child in the job
+-     table just as it would for a forked one. */
+-  sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
++  /* Successful spawn: run the unwind frame to perform the standard
++     cleanup (restore fds, cloexec flags, signal mask).  Signals stay
++     blocked until uw_fast_spawn_restore_sigmask fires last so that a
++     pending SIGCHLD cannot be delivered before register_spawned_child
++     has put the child in the job table. */
++  run_unwind_frame ("fast_spawn_command");
+ 
+   return pid;
+-
+-pipe_setup_fail:
+-  /* Restore everything we set up.  The order matches the cleanup path
+-     above: restore CLOEXEC on neighboring fds, then restore fd 1,
+-     then fd 0, then unblock signals.  saved_fd0/saved_fd1 may be -1
+-     if the corresponding setup never ran or never finished; close()
+-     and dup2() on -1 are skipped explicitly. */
+-  if (saved_cloexec)
+-    {
+-      for (i = 0; i < fds_to_close->size; i++)
+-	if (saved_cloexec[i] >= 0)
+-	  fcntl (i, F_SETFD, saved_cloexec[i]);
+-      free (saved_cloexec);
+-    }
+-  if (saved_fd1 >= 0)
+-    {
+-      dup2 (saved_fd1, 1);
+-      close (saved_fd1);
+-    }
+-  if (saved_fd0 >= 0)
+-    {
+-      dup2 (saved_fd0, 0);
+-      close (saved_fd0);
+-    }
+-  sigprocmask (SIG_SETMASK, &oset, (sigset_t *)NULL);
+-  return FAST_SPAWN_DECLINE;
+ }
+ 
+ /* Bypass the early fork in execute_simple_command for pipeline /
+-- 
+2.54.0.windows.1
+

--- a/bash/PKGBUILD
+++ b/bash/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=('bash' 'bash-devel')
 _basever=5.3
 _patchlevel=009 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="The GNU Bourne Again shell"
 arch=('i686' 'x86_64')
 license=('GPL')
@@ -28,7 +28,27 @@ source=(https://ftp.gnu.org/gnu/bash/bash-${_basever}.tar.gz{,.sig}
         0002-bash-4.3-msysize.patch
         0005-bash-4.3-msys2-fix-lineendings.patch
         0006-bash-4.3-add-pwd-W-option.patch
-        0007-fix-static-build.patch)
+        0007-fix-static-build.patch
+        0008-builtins-implement-expr.patch
+        0009-tests-cover-the-expr-builtin.patch
+        0010-tests-import-the-GNU-coreutils-expr-test-suite.patch
+        0011-jobs-add-register_spawned_child-.-for-non-fork-child.patch
+        0012-execute_cmd-introduce-nofastspawn-shopt-and-fast_spa.patch
+        0013-execute_cmd-introduce-FAST_SPAWN_-sentinels.patch
+        0014-execute_cmd-implement-fast-spawn-path-for-synchronou.patch
+        0015-execute_cmd-handle-simple-redirections-in-the-spawnv.patch
+        0016-execute_cmd-handle-pipeline-stages-in-the-spawnve-fa.patch
+        0017-execute_cmd-factor-out-shared-expand-resolve-helpers.patch
+        0018-execute_cmd-bypass-the-early-fork-in-pipeline-stages.patch
+        0019-execute_cmd-support-no-expansion-heredocs-in-the-fas.patch
+        0020-execute_cmd-extract-a-reusable-scanner-for-unsafe-wo.patch
+        0021-execute_cmd-support-expanding-heredocs-whose-body-is.patch
+        0022-execute_cmd-support-here-strings-word-in-the-spawnve.patch
+        0023-execute_cmd-support-async-commands-in-the-spawnve-fa.patch
+        0024-execute_cmd-remove-dead-REDIRECT_BOTH-bail-out-from-.patch
+        0025-execute_cmd-lift-fd-3-redirect-restriction-in-the-sp.patch
+        0026-execute_cmd-skip-fast-spawn-path-when-unable-to-repl.patch
+        0027-execute_cmd-wrap-the-spawnve-fast-path-in-an-unwind-.patch)
 if [ $_patchlevel -gt 000 ]; then
   for (( p=1; p<=$((10#${_patchlevel})); p++ )); do
     source=(${source[@]} https://ftp.gnu.org/gnu/bash/bash-${_basever}-patches/bash${_basever//./}-$(printf "%03d" $p){,.sig})
@@ -55,6 +75,36 @@ prepare() {
   patch -p1 -i ${srcdir}/0005-bash-4.3-msys2-fix-lineendings.patch
   patch -p1 -i ${srcdir}/0006-bash-4.3-add-pwd-W-option.patch
   patch -p1 -i ${srcdir}/0007-fix-static-build.patch
+
+  # Cygwin spawnve() fast path: skip fork()+execve() for synchronous
+  # external commands in favor of CreateProcess() via spawnve().  This
+  # is the work tracked in the bash-spawnve-fast-path topic; see the
+  # individual patch headers for details and benchmark numbers.
+  for p in \
+    0008-builtins-implement-expr.patch \
+    0009-tests-cover-the-expr-builtin.patch \
+    0010-tests-import-the-GNU-coreutils-expr-test-suite.patch \
+    0011-jobs-add-register_spawned_child-.-for-non-fork-child.patch \
+    0012-execute_cmd-introduce-nofastspawn-shopt-and-fast_spa.patch \
+    0013-execute_cmd-introduce-FAST_SPAWN_-sentinels.patch \
+    0014-execute_cmd-implement-fast-spawn-path-for-synchronou.patch \
+    0015-execute_cmd-handle-simple-redirections-in-the-spawnv.patch \
+    0016-execute_cmd-handle-pipeline-stages-in-the-spawnve-fa.patch \
+    0017-execute_cmd-factor-out-shared-expand-resolve-helpers.patch \
+    0018-execute_cmd-bypass-the-early-fork-in-pipeline-stages.patch \
+    0019-execute_cmd-support-no-expansion-heredocs-in-the-fas.patch \
+    0020-execute_cmd-extract-a-reusable-scanner-for-unsafe-wo.patch \
+    0021-execute_cmd-support-expanding-heredocs-whose-body-is.patch \
+    0022-execute_cmd-support-here-strings-word-in-the-spawnve.patch \
+    0023-execute_cmd-support-async-commands-in-the-spawnve-fa.patch \
+    0024-execute_cmd-remove-dead-REDIRECT_BOTH-bail-out-from-.patch \
+    0025-execute_cmd-lift-fd-3-redirect-restriction-in-the-sp.patch \
+    0026-execute_cmd-skip-fast-spawn-path-when-unable-to-repl.patch \
+    0027-execute_cmd-wrap-the-spawnve-fast-path-in-an-unwind-.patch
+  do
+    msg "applying patch $p"
+    patch -p1 -i ${srcdir}/$p
+  done
 
   autoconf
 }
@@ -95,7 +145,20 @@ build() {
 
 check() {
   cd ${srcdir}/${pkgname}-$_basever
-  make check
+  # The full upstream test suite (`make check` / `tests/run-all`) hangs
+  # on Cygwin/MSYS2 in CI, so restrict ourselves to the two `expr`
+  # suites added by this topic.
+  # `run-expr` exits non-zero via the standard `diff && rm` pattern when
+  # `expr.tests`'s output diverges from `expr.right`.
+  # `run-expr-coreutils` is self-tallying and exits non-zero when its
+  # internal `FAIL` counter is non-zero.  It must be invoked through our
+  # freshly built bash so that `expr` resolves to the builtin rather
+  # than to `/usr/bin/expr`.
+  (
+    cd tests
+    THIS_SH=../bash.exe BASH_TSTOUT=expr.out sh ./run-expr
+    THIS_SH=../bash.exe ../bash.exe ./run-expr-coreutils
+  )
 }
 
 package_bash() {
@@ -149,6 +212,26 @@ sha256sums=('0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba'
             '3c33be8d7363b00189309353f3fcdedfb7c7082c4a1cedbcc76a36fd0a8af8a8'
             'e123c1ef06499405f055d6c920cf267258d7ab3d59d6036e1ee2b5b0edd81ad2'
             'f70394dfe8afd8be94a8358732c4e55b4af069cb40555d1375f2dadee7554797'
+            'd77627ca4b3e0a8edddc27859588f70fcffff8ddd39439f21f7b94ae3d5d4489'
+            'bc38f442e449e088d9ed9ae4c1b923aaa8cc1f457271121f594e672404a43807'
+            'f27ae2d743cb4087c02e047987869691e2bceccba942c0b5b8bd4438fdb5e58c'
+            'c899aaba6a9403de865a65911d51c90f8f021a72e682cf65d34662729d6d85e9'
+            '5402762dbdf7e8c685ba69c86483afd5ebd84fba7bb537e98a614b82e7eadb70'
+            '6d88de2cac0285c336df776c3a07c4f02eaa03bddfc865ecd41b1326b1670359'
+            'f91c57b1cac8de720eef0bee1016b3a4c7ec6c7cb65824466f0d016f83134f73'
+            '2fdbcdaa75f650bac805d92a84f464ebf41470fd7d9a2bfe14ca9cad74c45025'
+            '214081cd76bcb3251f2cee89f73236f90144d224cdef6cecadca4a9a1abf7431'
+            '6be2030f631cf92af73f7f531cde9ffa87e5f5e495fd0e4ce5deca5c4e3f226a'
+            '147fa7d3946f2bbaa5610bcd125cb5b7a8e323f66ac4c76337f6d5930a43410e'
+            'f22e15c39be6e8202ed5034e1fe16305003bcf5ff93eea5ca0f0110bcbc13b8f'
+            '1d3721a3ad2463a6e8a36383214725422cf3636a7013ba6d54991c33480a7e19'
+            'e42a409a6e9a3f54faf3e04278b76dd5c40561160f1b129a206794f644a47498'
+            '1da268b7a794a508096232aee0cb824d8372280d33a6e5d7a733b7ec312f9896'
+            'a21bad941f97ae178d908f043b436fb50038a1ccbe3940a8165cb30e63d1f847'
+            'fcaa8d922485c3baa6ed20ede0ae8498747b7b89264d84613b8f71d4c0d0ddd8'
+            '8d26dfcf91bf5bb6d37ada58c3f0c5eefa9e94acf863799c6e7df5be64df16dd'
+            '3552fc94fd8c086920d3a3ba51ac8e3dd88350de576742fdf79bc29dcf00c189'
+            '52cc5aa0c92e13a2a165f9303ee30ba40d720066cb2ec49f51048b1becf855ca'
             '1f608434364af86b9b45c8b0ea3fb3b165fb830d27697e6cdfc7ac17dee3287f'
             'SKIP'
             'e385548a00130765ec7938a56fbdca52447ab41fabc95a25f19ade527e282001'


### PR DESCRIPTION
Git's test suite on Windows runs in roughly three to four times the wall-clock time of the same suite on Linux, and the dominant cause is `fork()`. Every shell script, every helper, every `$(expr ...)` substitution, every short `cmd | cmd` pipeline forces Cygwin's runtime to snapshot the parent's address space so that POSIX copy-on-write semantics can be emulated on top of `CreateProcess`. The test suite spawns a lot of those, and that cost is paid every push to `git-for-windows/git`, every contributor running the suite locally on their machine before opening a PR, every retry of a flaky job in CI.

This branch teaches `bash` to side-step `fork()` for the cases where the regular fork path would have behaved identically anyway, and to handle `expr` internally rather than spawning `/usr/bin/expr` for every arithmetic substitution. The cumulative payoff matters in two distinct ways: contributors get noticeably shorter iteration loops when running the test suite locally on Windows, and CI runs spend less time on a Windows runner per push. The Git for Windows CI in particular pays the `fork()` cost every time, and the savings compound across PRs, releases, and re-runs.

## Empirical evidence

Whole Git test suite, 17-way matrix, identical minimal SDK image, identical `git-artifacts`, the only variable being the `bash` binary:

| | wall-clock total | run |
|---|---|---|
| stock `bash` 5.3.009 | 32,401 s | [`bash-spawnve-baseline` 25742171983](https://github.com/dscho/MSYS2-packages/actions/runs/25742171983) |
| patched `bash` | 24,334 s | [`bash-spawnve-fast-path` 25742172112](https://github.com/dscho/MSYS2-packages/actions/runs/25742172112) |

That is a 25% reduction across 878 tests. No tests fail.

A handful of tests looked like regressions in single-shot timings; the worst was `t6433-merge-toplevel.sh` at a 1.24x ratio. To rule out CI scheduler noise, the sibling [`drill-bash-regression`](https://github.com/dscho/MSYS2-packages/tree/drill-bash-regression) workflow re-runs a single test 20 times under each variant on the same runner in randomized paired order, swapping both `bash.exe` and `sh.exe` between every iteration. For `t6433-merge-toplevel.sh` the result was:

| | mean over 20 runs |
|---|---|
| stock `bash` | 16.714 s |
| patched `bash` | 14.226 s |

Every one of the 20 paired iterations showed the patched build faster. The apparent regression in the whole-suite comparison was scheduler noise; the patched build has no code path that adds work over the baseline by mechanism, only paths that skip it. The same harness is available for any other test a reviewer wants spot-checked.

The workflow that produced the whole-suite numbers ships on this branch as `.github/workflows/bash-with-git-tests.yml` so the comparison can be reproduced on demand.

## Scope

The fast path is strictly gated on `__CYGWIN__`. Non-Windows MSYS2 environments are unaffected. The work deliberately does not touch the Cygwin runtime itself: a proper `posix_spawn()` integration there would require driving Jeremy Drake's stalled patches to completion and is much more invasive. Deferring that keeps this change isolated to the `bash` package alone while still delivering the bulk of the available speedup.
